### PR TITLE
fix: class and className of TVProps

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -41,33 +41,35 @@ export type TVScreenPropsValue<V extends TVVariants<S>, K extends keyof V> = {
 
 export type TVProps<V extends TVVariants<S>, S extends TVSlots> = {
   [K in keyof V]?: StringToBoolean<keyof V[K]> | TVScreenPropsValue<V, K>;
-} & ClassProp;
+} & ClassProp<ClassValue>;
 
-export type TVReturnType<V extends TVVariants<S>, S extends TVSlots, B extends ClassValue> = (
-  props?: TVProps<V, S>,
-) => S extends undefined
-  ? string
-  : {
-      [K in TVSlotsWithBase<S, B>]: (slotProps?: ClassProp) => string;
-    };
+export type TVReturnType<V extends TVVariants<S>, S extends TVSlots, B extends ClassValue> = {
+  (props?: TVProps<V, S>): S extends undefined
+    ? string
+    : {[K in TVSlotsWithBase<S, B>]: (slotProps?: ClassProp) => string};
+};
 
-export function tv<
-  V extends TVVariants<S>,
-  CV extends TVCompoundVariants<V, S, B>,
-  DV extends TVDefaultVariants<V, S>,
-  C extends TVConfig,
-  B extends ClassValue = undefined,
-  S extends TVSlots = undefined,
->(
-  options: {
-    base?: B;
-    slots?: S;
-    variants?: V;
-    compoundVariants?: CV;
-    defaultVariants?: DV;
-  },
-  config?: C,
-): TVReturnType<V, S, B>;
+export type TV = {
+  <
+    V extends TVVariants<S> = {},
+    CV extends TVCompoundVariants<V, S, B> = [],
+    DV extends TVDefaultVariants<V, S> = {},
+    C extends TVConfig,
+    B extends ClassValue = undefined,
+    S extends TVSlots = undefined,
+  >(
+    options: {
+      base?: B;
+      slots?: S;
+      variants?: V;
+      compoundVariants?: CV;
+      defaultVariants?: DV;
+    },
+    config?: C,
+  ): TVReturnType<V, S, B>;
+};
+
+export declare const tv: TV;
 
 export type VariantProps<Component extends (...args: any) => any> = Omit<
   OmitUndefined<Parameters<Component>[0]>,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixed `class, className` type error and auto-suggestion hint.

- Add `ClassValue` generic for `ClassProp`.
- Provide default types for `TVVariants, TVCompoundVariants, TVDefaultVariants` for better type inference.

### Additional context

- Define `function tv` as a `TV` type to be easily exported.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
