### PR TITLE
feat: on-demand transform

### DIFF
--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -14,7 +14,7 @@ const mock: Mock = {
   transformer: (content) => `tv transformer: ${tvTransformer(content, defaultScreens)}`,
 };
 
-const expectedContent = (sourceCode: string, transformed: object[]) => {
+const expectedContent = (sourceCode: string, transformed: (object | null)[]) => {
   const prefix = "\n/* Tailwind Variants Transformed Content Start\n\n";
   const suffix = "\n\nTailwind Variants Transformed Content End */\n";
 
@@ -25,10 +25,22 @@ describe("Responsive Variants", () => {
   afterEach(() => jest.restoreAllMocks());
 
   test("should return a transformed content (string)", () => {
-    const tvImport = 'import {tv} from "tailwind-variants";';
-    const tvComponent =
-      'const button = tv({ variants: { color: { primary: "text-blue-50 bg-blue-600 rounded" } } });';
-    const sourceCode = tvImport.concat(tvComponent);
+    const sourceCode = `
+      import {tv} from "tailwind-variants";
+
+      const button = tv(
+        {
+          variants: {
+            color: {
+              primary: "text-blue-50 bg-blue-600 rounded"
+            }
+          }
+        },
+        {
+          responsiveVariants: true
+        }
+      );
+    `;
 
     const result = tvTransformer(sourceCode, defaultScreens);
 
@@ -51,10 +63,22 @@ describe("Responsive Variants", () => {
   });
 
   test("should return a transformed content (array)", () => {
-    const tvImport = 'import {tv} from "tailwind-variants";';
-    const tvComponent =
-      'const button = tv({ variants: { color: { primary: ["text-blue-50", "bg-blue-600", "rounded"] } } });';
-    const sourceCode = tvImport.concat(tvComponent);
+    const sourceCode = `
+      import {tv} from "tailwind-variants";
+
+      const button = tv(
+        {
+          variants: {
+            color: {
+              primary: ["text-blue-50", "bg-blue-600", "rounded"]
+            }
+          }
+        },
+        {
+          responsiveVariants: true
+        }
+      );
+    `;
 
     const result = tvTransformer(sourceCode, defaultScreens);
 
@@ -77,10 +101,22 @@ describe("Responsive Variants", () => {
   });
 
   test("should return a transformed content (nested array)", () => {
-    const tvImport = 'import {tv} from "tailwind-variants";';
-    const tvComponent =
-      'const button = tv({ variants: { color: { primary: [["text-blue-50", "bg-blue-600"], "rounded"] } } });';
-    const sourceCode = tvImport.concat(tvComponent);
+    const sourceCode = `
+      import {tv} from "tailwind-variants";
+
+      const button = tv(
+        {
+          variants: {
+            color: {
+              primary: [["text-blue-50", "bg-blue-600"], "rounded"]
+            }
+          }
+        },
+        {
+          responsiveVariants: true
+        }
+      );
+    `;
 
     const result = tvTransformer(sourceCode, defaultScreens);
 
@@ -103,10 +139,27 @@ describe("Responsive Variants", () => {
   });
 
   test("should return a transformed content (responsive slot variant)", () => {
-    const tvImport = 'import {tv} from "tailwind-variants";';
-    const tvComponent =
-      'const button = tv({ slots: { base: "flex" }, variants: { color: { primary: { base: ["bg-blue-50 text-blue-900", ["dark:bg-blue-900", "dark:text-blue-50"]] } } } });';
-    const sourceCode = tvImport.concat(tvComponent);
+    const sourceCode = `
+      import {tv} from "tailwind-variants";
+
+      const button = tv(
+        {
+          slots: {
+            base: "flex"
+          },
+          variants: {
+            color: {
+              primary: {
+                base: ["bg-blue-50 text-blue-900", ["dark:bg-blue-900", "dark:text-blue-50"]]
+              }
+            }
+          }
+        },
+        {
+          responsiveVariants: true
+        }
+      );
+    `;
 
     const result = tvTransformer(sourceCode, defaultScreens);
 
@@ -122,6 +175,123 @@ describe("Responsive Variants", () => {
               xl: "xl:bg-blue-50 xl:text-blue-900 xl:dark:bg-blue-900 xl:dark:text-blue-50",
               "2xl": "2xl:bg-blue-50 2xl:text-blue-900 2xl:dark:bg-blue-900 2xl:dark:text-blue-50",
             },
+          },
+        },
+      },
+    ];
+
+    expect(result).toBe(expectedContent(sourceCode, transformedContent));
+  });
+
+  test("should return a transformed content (on-demand responsive variants - screens)", () => {
+    const sourceCode = `
+      import {tv} from "tailwind-variants";
+
+      const button = tv(
+        {
+          variants: {
+            color: {
+              primary: "text-blue-50 bg-blue-600 rounded"
+            }
+          }
+        },
+        {
+          responsiveVariants: ["sm", "md"]
+        }
+      );
+    `;
+
+    const result = tvTransformer(sourceCode, defaultScreens);
+
+    const transformedContent = [
+      {
+        color: {
+          primary: {
+            original: "text-blue-50 bg-blue-600 rounded",
+            sm: "sm:text-blue-50 sm:bg-blue-600 sm:rounded",
+            md: "md:text-blue-50 md:bg-blue-600 md:rounded",
+          },
+        },
+      },
+    ];
+
+    expect(result).toBe(expectedContent(sourceCode, transformedContent));
+  });
+
+  test("should return a transformed content (on-demand responsive variants - variants)", () => {
+    const sourceCode = `
+      import {tv} from "tailwind-variants";
+
+      const button = tv(
+        {
+          variants: {
+            color: {
+              primary: "text-blue-50 bg-blue-600 rounded"
+            }
+          }
+        },
+        {
+          responsiveVariants: {
+            color: ["sm"]
+          }
+        }
+      );
+    `;
+
+    const result = tvTransformer(sourceCode, defaultScreens);
+
+    const transformedContent = [
+      [
+        {
+          color: {
+            primary: {
+              original: "text-blue-50 bg-blue-600 rounded",
+              sm: "sm:text-blue-50 sm:bg-blue-600 sm:rounded",
+            },
+          },
+        },
+      ],
+    ];
+
+    expect(result).toBe(expectedContent(sourceCode, transformedContent));
+  });
+
+  test("should return a transformed content (with extend)", () => {
+    const sourceCode = `
+      import {tv} from "tailwind-variants";
+
+      const baseButton = tv({
+        base: "px-2"
+      });
+
+      const button = tv(
+        {
+          extend: baseButton,
+          variants: {
+            color: {
+              primary: "text-blue-50 bg-blue-600 rounded"
+            }
+          }
+        },
+        {
+          responsiveVariants: true
+        }
+      );
+    `;
+
+    const result = tvTransformer(sourceCode, defaultScreens);
+
+    const transformedContent = [
+      null,
+      {
+        color: {
+          primary: {
+            original: "text-blue-50 bg-blue-600 rounded",
+            sm: "sm:text-blue-50 sm:bg-blue-600 sm:rounded",
+            md: "md:text-blue-50 md:bg-blue-600 md:rounded",
+            lg: "lg:text-blue-50 lg:bg-blue-600 lg:rounded",
+            xl: "xl:text-blue-50 xl:bg-blue-600 xl:rounded",
+            "2xl": "2xl:text-blue-50 2xl:bg-blue-600 2xl:rounded",
           },
         },
       },

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -1,6 +1,8 @@
 import type {Config as TwMergeConfig} from "tailwind-merge";
+import type {TVVariants} from "./index";
+import type {TVGeneratedScreens} from "./generated";
 
-export type TVConfig = {
+export type TVConfig<V extends TVVariants<S>, EV extends TVVariants> = {
   /**
    * Whether to merge the class names with `tailwind-merge` library.
    * It's avoid to have duplicate tailwind classes. (Recommended)
@@ -13,4 +15,13 @@ export type TVConfig = {
    * @see https://github.com/dcastil/tailwind-merge/blob/v1.8.1/docs/configuration.md
    */
   twMergeConfig?: TwMergeConfig;
+  /**
+   * Whether to enable responsive variant transform.
+   * Which variants or screens(breakpoints) for responsive variant transform.
+   * @default false
+   */
+  responsiveVariants?:
+    | boolean
+    | TVGeneratedScreens[]
+    | {[K in keyof V | keyof EV]?: boolean | TVGeneratedScreens[]};
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -151,7 +151,7 @@ export type TV = {
     V extends TVVariants<S, B, EV> = undefined,
     CV extends TVCompoundVariants<V, EV, S, B> = undefined,
     DV extends TVDefaultVariants<V, EV, S> = undefined,
-    C extends TVConfig,
+    C extends TVConfig<V, EV>,
     B extends ClassValue = undefined,
     S extends TVSlots = undefined,
     E extends ReturnType<TV> = undefined,

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -3,8 +3,8 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import {generateTypes} from "./generator";
 
 const regExp = {
-  tv: /tv\({[\s\S]*?}\)/g,
-  tvContent: /\({[\s\S]*?}\)/g,
+  tv: /tv\s*\((.*?)\)/gs,
+  tvExtend: /extend:\s*\w+,\s*/,
   comment: /\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm,
   blankLine: /^\s*$(?:\r\n?|\n)/gm,
   extension: /\.\w+/g,
@@ -16,6 +16,8 @@ const isString = (param) => typeof param === "string";
 
 const isObject = (param) => typeof param === "object";
 
+const isBoolean = (param) => typeof param === "boolean";
+
 const isFunction = (param) => typeof param === "function";
 
 const isEmpty = (param) => {
@@ -25,6 +27,20 @@ const isEmpty = (param) => {
   if (isObject(param) && Object.keys(param).length === 0) return true;
 
   return false;
+};
+
+const pickByKeys = (target, keys) => {
+  const result = {};
+  const length = keys.length;
+  const hasOwnProp = Object.prototype.hasOwnProperty;
+
+  for (let i = 0; i < length; i++) {
+    const key = keys[i];
+
+    if (hasOwnProp.call(target, key)) result[key] = target[key];
+  }
+
+  return result;
 };
 
 const printError = (message, error) => {
@@ -44,7 +60,10 @@ const getCleanContent = (content) => {
   const removeComment = content.replace(regExp.comment, "$1").toString();
   const removeBlankLine = removeComment.replace(regExp.blankLine, "").toString();
 
-  return removeBlankLine.match(regExp.tv);
+  // TODO: support inline tv
+  const removeExtend = (match) => match[1].replace(regExp.tvExtend, "").toString();
+
+  return Array.from(removeBlankLine.matchAll(regExp.tv), removeExtend);
 };
 
 const getTVObjects = (content) => {
@@ -57,7 +76,10 @@ const getTVObjects = (content) => {
      * avoid direct eval
      * @see https://esbuild.github.io/content-types/#direct-eval
      */
-    return new Function(`return ${tv.match(regExp.tvContent).toString()}`)();
+    return new Function(`
+      const [options, config] = [${tv.toString()}];
+      return {options, config};
+    `)();
   });
 };
 
@@ -105,11 +127,7 @@ const getVariants = (classNames, screens) => {
   return classNames;
 };
 
-const transformContent = (tv, screens) => {
-  const {variants = {}} = tv;
-
-  if (isEmpty(variants)) return;
-
+const transformVariantsByScreens = (variants, screens) => {
   let responsive = {};
 
   for (const [variantName, variant] of Object.entries(variants)) {
@@ -146,6 +164,43 @@ const transformContent = (tv, screens) => {
   }
 
   return responsive;
+};
+
+const transformContent = ({options, config}, screens) => {
+  const variants = options?.variants ?? {};
+  const responsiveVariants = config?.responsiveVariants ?? false;
+
+  if (!responsiveVariants || isEmpty(variants)) return;
+
+  // responsiveVariants: true
+  if (isBoolean(responsiveVariants)) {
+    return transformVariantsByScreens(variants, screens);
+  }
+
+  // responsiveVariants: [...]
+  if (isArray(responsiveVariants)) {
+    return transformVariantsByScreens(variants, responsiveVariants);
+  }
+
+  // responsiveVariants: {...}
+  if (isObject(responsiveVariants)) {
+    const onDemand = [];
+
+    for (const [variantName, onDemandConfig] of Object.entries(responsiveVariants)) {
+      if (!onDemandConfig || isEmpty(onDemandConfig)) continue;
+
+      const onDemandVariants = pickByKeys(variants, [variantName]);
+
+      const tv = {
+        options: {variants: onDemandVariants},
+        config: {responsiveVariants: onDemandConfig},
+      };
+
+      onDemand.push(transformContent(tv, screens));
+    }
+
+    return onDemand;
+  }
 };
 
 export const tvTransformer = (content, screens) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- [x] On-Demand transform.
- [x] New config api `responsiveVariants`.
- [x] Fixed issue with failed transformwhen using `extend`.

### Additional context

#### Usage

- `responsiveVariants` set to `false` by default.

```tsx
import { tv } from 'tailwind-variants';

const button = tv(
  {
    variants: {
      color: {
        primary: '...',
        secondary: '...'
      },
      size: {
        sm: '...',
        md: '...'
      }
    }
  },
  {
    // Transform all variants under every screen.
    responsiveVariants: true,

    // Transform all variants under the specified screens.
    responsiveVariants: ["sm", "md"],

    // Transform specified variants.
    responsiveVariants: {
      // Transform color variant under every screen.
      color: true,
      // Transform size variant under specified screens.
      size: ["sm", "md"]
    }
  }
);

const App = () => {

  return (
    <button className={button({ size: { initial: "sm", lg: "md" } })}>
      Label
    </button>
  );
};
```

```javascript
const { withTV } = require('tailwind-variants/transformer');

/**
 * Tailwind Config
 *
 * @type {import('tailwindcss').Config}
 */
const tailwindConfig = {
  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
  theme: {},
  plugins: []
};

module.exports = withTV(tailwindConfig)
```

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
