### PR TITLE
fix: exclude transform without responsive variants

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -4,7 +4,7 @@ import {generateTypes} from "./generator";
 
 const regExp = {
   tv: /tv\s*\((.*?)\)/gs,
-  tvExtend: /extend:\s*\w+,\s*/,
+  tvExtend: /extend:\s*\w+(,| )\s*/,
   comment: /\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm,
   blankLine: /^\s*$(?:\r\n?|\n)/gm,
   extension: /\.\w+/g,
@@ -72,6 +72,8 @@ const getTVObjects = (content) => {
   if (isEmpty(tvs)) return;
 
   return tvs.map((tv) => {
+    if (!tv.includes("responsiveVariants")) return {};
+
     /**
      * avoid direct eval
      * @see https://esbuild.github.io/content-types/#direct-eval


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Exclude transform without `responsiveVariants` config to avoid warnings in the terminal.

### Additional context

-  Updated the regular expression for `extend`.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
