### PR TITLE
feat: avoid empty strings in the result

### DIFF
--- a/src/__tests__/tv.test.ts
+++ b/src/__tests__/tv.test.ts
@@ -1,4 +1,4 @@
-import {tv} from "../index";
+import {tv, cn} from "../index";
 
 const resultArray = (result: string) => result.split(" ");
 
@@ -179,7 +179,7 @@ describe("Tailwind Variants (TV) - Default", () => {
 
   test("should work without anything", () => {
     const styles = tv({});
-    const expectedResult = "";
+    const expectedResult = undefined;
 
     expect(styles()).toBe(expectedResult);
   });
@@ -355,10 +355,12 @@ describe("Tailwind Variants (TV) - Slots", () => {
 
     const {base, title, item, list} = menu();
 
-    expectTv(base(), []);
-    expectTv(title(), []);
-    expectTv(item(), []);
-    expectTv(list(), []);
+    const expectedResult = undefined;
+
+    expect(base()).toBe(expectedResult);
+    expect(title()).toBe(expectedResult);
+    expect(item()).toBe(expectedResult);
+    expect(list()).toBe(expectedResult);
   });
 
   test("should work with slots -- default variants -- custom class & className", () => {
@@ -2362,5 +2364,20 @@ describe("Tailwind Variants (TV) - Extends", () => {
       "color--red--wrapper--menuBase",
       "color--red--isBig--wrapper--menuBase",
     ]);
+  });
+
+  test("should work with cn", () => {
+    const tvResult = ["w-fit", "h-fit"];
+    const custom = ["w-full"];
+
+    const resultWithoutMerge = cn(tvResult.concat(custom))({twMerge: false});
+    const resultWithMerge = cn(tvResult.concat(custom))({twMerge: true});
+    const emptyResultWithoutMerge = cn([].concat([]))({twMerge: false});
+    const emptyResultWithMerge = cn([].concat([]))({twMerge: true});
+
+    expect(resultWithoutMerge).toBe("w-fit h-fit w-full");
+    expect(resultWithMerge).toBe("h-fit w-full");
+    expect(emptyResultWithoutMerge).toBe(undefined);
+    expect(emptyResultWithMerge).toBe(undefined);
   });
 });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -35,7 +35,7 @@ export type StringToBoolean<T> = T extends "true" | "false" ? boolean : T;
 
 export type CnOptions = ClassValue[];
 
-export type CnReturn = string;
+export type CnReturn = string | undefined;
 
 export declare const cnBase: <T extends CnOptions>(...classes: T) => CnReturn;
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,20 +14,22 @@ export const defaultConfig = {
   responsiveVariants: false,
 };
 
+export const voidEmpty = (value) => (!!value ? value : undefined);
+
 export const cnBase = (...classes) => classes.flat(Infinity).filter(Boolean).join(" ");
 
 export const cn =
   (...classes) =>
   (config = defaultConfig) => {
     if (!config.twMerge) {
-      return cnBase(classes);
+      return voidEmpty(cnBase(classes));
     }
 
     const twMerge = !isEmptyObject(config.twMergeConfig)
       ? extendTailwindMerge(config.twMergeConfig)
       : twMergeBase;
 
-    return twMerge(cnBase(classes));
+    return voidEmpty(twMerge(cnBase(classes)));
   };
 
 const joinObjects = (obj1, obj2) => {

--- a/src/index.js
+++ b/src/index.js
@@ -16,13 +16,13 @@ export const defaultConfig = {
 
 export const voidEmpty = (value) => (!!value ? value : undefined);
 
-export const cnBase = (...classes) => classes.flat(Infinity).filter(Boolean).join(" ");
+export const cnBase = (...classes) => voidEmpty(classes.flat(Infinity).filter(Boolean).join(" "));
 
 export const cn =
   (...classes) =>
   (config = defaultConfig) => {
     if (!config.twMerge) {
-      return voidEmpty(cnBase(classes));
+      return cnBase(classes);
     }
 
     const twMerge = !isEmptyObject(config.twMergeConfig)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Avoiding empty strings in the result to get a cleaner DOM.

### Additional context

DOM example with empty result.

#### Before
```html
<div class>...</div>
```

#### After
```html
<div>...</div>
```

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
