### PR TITLE
Use `TVReturnType` to prevent circular references

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,7 +42,7 @@ export declare const cnBase: <T extends CnOptions>(...classes: T) => CnReturn;
 export declare const cn: <T extends CnOptions>(...classes: T) => (config?: TWMConfig) => CnReturn;
 
 // compare if the value is true or array of values
-export type isTrueOrArray<T> = T extends true | (infer U)[] ? true : false;
+export type isTrueOrArray<T> = T extends true | unknown[] ? true : false;
 
 export type isStringArray<T> = T extends Array<string> ? true : false;
 
@@ -192,7 +192,7 @@ export type TV = {
     C extends TVConfig<V, EV> = undefined,
     B extends ClassValue = undefined,
     S extends TVSlots = undefined,
-    E extends ReturnType<TV> = undefined,
+    E extends TVReturnType = undefined,
     EV extends TVVariants = E["variants"] extends TVVariants ? E["variants"] : undefined,
     ES extends TVSlots = E["slots"] extends TVSlots ? E["slots"] : undefined,
   >(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The TypeScript types were behaving very slow and after some digging it was due to a circular reference from `ReturnType<TV>`. Swapping that out with `TVReturnType` drastically improves the experience in the editor.

There are a bunch of other issues with the types related to missing generic arguments and such that I plan on helping fix in future PRs, but wanted to get this out there since it's a small fix with a big performance improvement.

### Additional context

The videos below show the difference in time for errors appearing before and after this change.

#### Before

https://user-images.githubusercontent.com/25914066/234464472-79fb3025-0448-48aa-bdee-43781b6c4111.mov

#### After

https://user-images.githubusercontent.com/25914066/234464481-0a6dbc7b-7c83-4e95-8ffb-260dd5ed75e5.mov


### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
