### PR TITLE
Fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
       "esm"
     ]
   },
-  "packageManager": "pnpm@7.14.2",
+  "packageManager": "pnpm@8.3.1",
   "engines": {
     "node": ">=16.x",
     "pnpm": ">=7.x"

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -17,7 +17,10 @@ export type TWMConfig = {
   twMergeConfig?: TwMergeConfig;
 };
 
-export type TVConfig<V extends TVVariants<S>, EV extends TVVariants> = {
+export type TVConfig<
+  V extends TVVariants | undefined = undefined,
+  EV extends TVVariants | undefined = undefined,
+> = {
   /**
    * Whether to enable responsive variant transform.
    * Which variants or screens(breakpoints) for responsive variant transform.

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -18,7 +18,9 @@ export type TWMConfig = {
 };
 
 export type TVConfig<
+  // @ts-expect-error
   V extends TVVariants | undefined = undefined,
+  // @ts-expect-error
   EV extends TVVariants | undefined = undefined,
 > = {
   /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -213,7 +213,9 @@ export type TV = {
     C extends TVConfig<V, EV>,
     B extends ClassValue = undefined,
     S extends TVSlots = undefined,
+    // @ts-expect-error
     E extends TVReturnType = undefined,
+    // @ts-expect-error
     EV extends TVVariants = E["variants"] extends TVVariants ? E["variants"] : undefined,
     ES extends TVSlots = E["slots"] extends TVSlots ? E["slots"] : undefined,
   >(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,8 +44,6 @@ export declare const cn: <T extends CnOptions>(...classes: T) => (config?: TWMCo
 // compare if the value is true or array of values
 export type isTrueOrArray<T> = T extends true | unknown[] ? true : false;
 
-export type isStringArray<T> = T extends Array<string> ? true : false;
-
 export type WithInitialScreen<T extends Array<string>> = ["initial", ...T];
 
 /**
@@ -69,9 +67,10 @@ type TVVariantsDefault<S extends TVSlots, B extends ClassValue> = {
 };
 
 export type TVVariants<
-  S extends TVSlots,
-  B extends ClassValue,
-  EV extends TVVariants = undefined,
+  S extends TVSlots | undefined,
+  B extends ClassValue | undefined = undefined,
+  EV extends TVVariants<ES> | undefined = undefined,
+  ES extends TVSlots | undefined = undefined,
 > = EV extends undefined
   ? TVVariantsDefault<S, B>
   :
@@ -87,14 +86,16 @@ export type TVVariants<
 
 export type TVCompoundVariants<
   V extends TVVariants<S>,
-  EV extends TVVariants,
   S extends TVSlots,
   B extends ClassValue,
+  EV extends TVVariants<ES>,
+  ES extends TVSlots,
 > = Array<
   {
     [K in keyof V | keyof EV]?:
-      | StringToBoolean<keyof V[K] | keyof EV[K]>
-      | StringToBoolean<keyof V[K]>[];
+      | (K extends keyof V ? StringToBoolean<keyof V[K]> : never)
+      | (K extends keyof EV ? StringToBoolean<keyof EV[K]> : never)
+      | (K extends keyof V ? StringToBoolean<keyof V[K]>[] : never);
   } & ClassProp<SlotsClassValue<S, B> | ClassValue>
 >;
 
@@ -114,15 +115,23 @@ export type TVCompoundSlots<
       } & ClassProp
 >;
 
-export type TVDefaultVariants<V extends TVVariants<S>, EV extends TVVariants, S extends TVSlots> = {
-  [K in keyof V | keyof EV]?: StringToBoolean<keyof V[K] | keyof EV[K]>;
+export type TVDefaultVariants<
+  V extends TVVariants<S>,
+  S extends TVSlots,
+  EV extends TVVariants<ES>,
+  ES extends TVSlots,
+> = {
+  [K in keyof V | keyof EV]?:
+    | (K extends keyof V ? StringToBoolean<keyof V[K]> : never)
+    | (K extends keyof EV ? StringToBoolean<keyof EV[K]> : never);
 };
 
 export type TVScreenPropsValue<
-  V extends TVVariants,
+  V extends TVVariants<S>,
+  S extends TVSlots,
   K extends keyof V,
   C extends TVConfig,
-> = isStringArray<C["responsiveVariants"]> extends true
+> = C["responsiveVariants"] extends string[]
   ? {
       [Screen in WithInitialScreen<C["responsiveVariants"]>[number]]?: StringToBoolean<keyof V[K]>;
     }
@@ -132,64 +141,76 @@ export type TVScreenPropsValue<
 
 export type TVProps<
   V extends TVVariants<S>,
-  EV extends TVVariants,
   S extends TVSlots,
   C extends TVConfig<V, EV>,
+  EV extends TVVariants<ES>,
+  ES extends TVSlots,
 > = EV extends undefined
   ? V extends undefined
     ? ClassProp<ClassValue>
     : {
         [K in keyof V]?: isTrueOrArray<C["responsiveVariants"]> extends true
-          ? StringToBoolean<keyof V[K]> | TVScreenPropsValue<V, K, C>
+          ? StringToBoolean<keyof V[K]> | TVScreenPropsValue<V, S, K, C>
           : StringToBoolean<keyof V[K]>;
       } & ClassProp<ClassValue>
   : V extends undefined
   ? {
       [K in keyof EV]?: isTrueOrArray<C["responsiveVariants"]> extends true
-        ? StringToBoolean<keyof EV[K]> | TVScreenPropsValue<EV, K, C>
+        ? StringToBoolean<keyof EV[K]> | TVScreenPropsValue<EV, ES, K, C>
         : StringToBoolean<keyof EV[K]>;
     } & ClassProp<ClassValue>
   : {
       [K in keyof V | keyof EV]?: isTrueOrArray<C["responsiveVariants"]> extends true
-        ? StringToBoolean<keyof V[K] | keyof EV[K]> | TVScreenPropsValue<EV & V, K, C>
-        : StringToBoolean<keyof V[K] | keyof EV[K]>;
+        ?
+            | (K extends keyof V ? StringToBoolean<keyof V[K]> : never)
+            | (K extends keyof EV ? StringToBoolean<keyof EV[K]> : never)
+            | TVScreenPropsValue<EV & V, S, K, C>
+        :
+            | (K extends keyof V ? StringToBoolean<keyof V[K]> : never)
+            | (K extends keyof EV ? StringToBoolean<keyof EV[K]> : never);
     } & ClassProp<ClassValue>;
 
 export type TVVariantKeys<V extends TVVariants<S>, S extends TVSlots> = V extends Object
   ? Array<keyof V>
   : undefined;
 
-export type TVReturnProps<V extends TVVariants<S>, S extends TVSlots, B extends ClassValue> = {
+export type TVReturnProps<
+  V extends TVVariants<S>,
+  S extends TVSlots,
+  B extends ClassValue,
+  EV extends TVVariants<ES>,
+  ES extends TVSlots,
+> = {
   base: B;
   slots: S;
   variants: V;
-  defaultVariants: TVDefaultVariants<V, S>;
-  compoundVariants: TVCompoundVariants<V, S, B>;
+  defaultVariants: TVDefaultVariants<V, S, EV, ES>;
+  compoundVariants: TVCompoundVariants<V, S, B, EV, ES>;
   compoundSlots: TVCompoundSlots<V, S, B>;
   variantKeys: TVVariantKeys<V, S>;
 };
 
 export type TVReturnType<
   V extends TVVariants<S>,
-  EV extends TVVariants,
   S extends TVSlots,
-  ES extends TVSlots,
   B extends ClassValue,
   C extends TVConfig<V, EV>,
+  EV extends TVVariants<ES>,
+  ES extends TVSlots,
 > = {
-  (props?: TVProps<V, EV, S, C>): ES extends undefined
+  (props?: TVProps<V, S, C, EV, ES>): ES extends undefined
     ? S extends undefined
       ? string
       : {[K in TVSlotsWithBase<S, B>]: (slotProps?: ClassProp) => string}
     : {[K in TVSlotsWithBase<ES & S, B>]: (slotProps?: ClassProp) => string};
-} & TVReturnProps<V, S, B>;
+} & TVReturnProps<V, S, B, EV, ES>;
 
 export type TV = {
   <
-    V extends TVVariants<S, B, EV> = undefined,
-    CV extends TVCompoundVariants<V, EV, S, B> = undefined,
-    DV extends TVDefaultVariants<V, EV, S> = undefined,
-    C extends TVConfig<V, EV> = undefined,
+    V extends TVVariants<S, B, EV>,
+    CV extends TVCompoundVariants<V, S, B, EV, ES>,
+    DV extends TVDefaultVariants<V, S, EV, ES>,
+    C extends TVConfig<V, EV>,
     B extends ClassValue = undefined,
     S extends TVSlots = undefined,
     E extends TVReturnType = undefined,
@@ -236,7 +257,7 @@ export type TV = {
      * @see https://www.tailwind-variants.org/docs/api-reference#config-optional
      */
     config?: C,
-  ): TVReturnType<V, EV, S, ES, B, C>;
+  ): TVReturnType<V, S, B, C, EV, ES>;
 };
 
 // main function

--- a/src/transformer.d.ts
+++ b/src/transformer.d.ts
@@ -4,7 +4,7 @@ import type {DefaultTheme} from "tailwindcss/types/generated/default-theme";
 export type DefaultScreens = keyof DefaultTheme["screens"];
 
 export type WithTV = {
-  <C extends Config = {}>(tvConfig: Config): C;
+  (tvConfig: Config): Config;
 };
 
 export declare const withTV: WithTV;

--- a/src/transformer.d.ts
+++ b/src/transformer.d.ts
@@ -4,7 +4,7 @@ import type {DefaultTheme} from "tailwindcss/types/generated/default-theme";
 export type DefaultScreens = keyof DefaultTheme["screens"];
 
 export type WithTV = {
-  (tvConfig: Config): Config;
+  <C extends Config>(tvConfig: C): C;
 };
 
 export declare const withTV: WithTV;

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -1,0 +1,9 @@
+export declare const falsyToString: <T>(value: T) => T | string;
+
+export declare const isEmptyObject: (obj: unknown) => boolean;
+
+export declare const flatMergeArrays: <T extends unknown[]>(...arrays: T[]) => T;
+
+export declare const mergeObjects: (obj1: unknown, obj2: unknown) => unknown;
+
+export declare const removeExtraSpaces: (str: string) => string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,16 @@
-
-{	
-  "$schema": "https://json.schemastore.org/tsconfig",	
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist"],	
-  "compilerOptions": {	
-    "target": "esnext",	
-    "module": "esnext",	
-    "isolatedModules": true,	
-    "esModuleInterop": true,	
-    "moduleResolution": "node",	
-    "resolveJsonModule": true,	
-    "strict": true,	
-    "declaration": true,	
-    "skipLibCheck": true,	
-    "allowJs": false	
-  }	
-}	
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "strict": true,
+    "declaration": true,
+    "allowJs": false
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Quite a bit going on in this PR, but broken down there are two main goals.

1. Disable `skipLibCheck` as that also disables checking `d.ts` files in this repo. This would have caught the circular type reference issue in https://github.com/nextui-org/tailwind-variants/pull/39.
2. Fix all existing type errors in the `d.ts` files.

Fixes #33 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
