### PR TITLE
fix: VariantProps are of type any

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -267,7 +267,8 @@ export declare const tv: TV;
 
 export declare const defaultConfig: TVConfig;
 
-export type VariantProps<Component extends (...args: any) => any> = Omit<
-  OmitUndefined<Parameters<Component>[0]>,
-  "class" | "className"
->;
+export type VariantProps<T> = T extends {variants: infer V}
+  ? V extends TVVariantsDefault<any, undefined>
+    ? {[K in TVVariantKeys<V, any>[number]]?: keyof V[K]}
+    : never
+  : never;


### PR DESCRIPTION
### Description

When using the VariantProps generic all of the returned types are now literals instead of any.

### What is the purpose of this pull request?

#56 

this now gets the proper variant types

![twvarfix](https://github.com/nextui-org/tailwind-variants/assets/86675944/93c5e30f-c437-46e3-aa39-b00d85892c05)


- [x ] Bug fix



