### PR TITLE
fix: support typescript 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "jest --verbose"
   },
   "dependencies": {
-    "tailwind-merge": "^1.10.0"
+    "tailwind-merge": "^1.13.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.2.0",
@@ -67,7 +67,7 @@
     "ts-node": "^10.9.1",
     "tslib": "^2.4.1",
     "tsup": "6.6.3",
-    "typescript": "4.9.5",
+    "typescript": "5.1.3",
     "webpack": "^5.53.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   tailwind-merge:
-    specifier: ^1.10.0
-    version: 1.10.0
+    specifier: ^1.13.2
+    version: 1.13.2
 
 devDependencies:
   '@commitlint/cli':
@@ -18,7 +18,7 @@ devDependencies:
     version: 17.4.2
   '@swc-node/jest':
     specifier: ^1.5.2
-    version: 1.5.6(@swc/core@1.2.198)(typescript@4.9.5)
+    version: 1.5.6(@swc/core@1.2.198)(typescript@5.1.3)
   '@swc/cli':
     specifier: 0.1.57
     version: 0.1.57(@swc/core@1.2.198)
@@ -36,10 +36,10 @@ devDependencies:
     version: 18.11.18
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.42.0
-    version: 5.48.1(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@4.9.5)
+    version: 5.48.1(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@5.1.3)
   '@typescript-eslint/parser':
     specifier: ^5.42.0
-    version: 5.48.1(eslint@7.32.0)(typescript@4.9.5)
+    version: 5.48.1(eslint@7.32.0)(typescript@5.1.3)
   clean-package:
     specifier: 2.1.1
     version: 2.1.1
@@ -51,7 +51,7 @@ devDependencies:
     version: 8.6.0(eslint@7.32.0)
   eslint-config-ts-lambdas:
     specifier: ^1.2.3
-    version: 1.2.3(@typescript-eslint/eslint-plugin@5.48.1)(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@4.9.5)
+    version: 1.2.3(@typescript-eslint/eslint-plugin@5.48.1)(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@5.1.3)
   eslint-import-resolver-typescript:
     specifier: ^2.4.0
     version: 2.7.1(eslint-plugin-import@2.27.4)(eslint@7.32.0)
@@ -63,7 +63,7 @@ devDependencies:
     version: 2.27.4(@typescript-eslint/parser@5.48.1)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
   eslint-plugin-jest:
     specifier: ^24.3.6
-    version: 24.7.0(@typescript-eslint/eslint-plugin@5.48.1)(eslint@7.32.0)(typescript@4.9.5)
+    version: 24.7.0(@typescript-eslint/eslint-plugin@5.48.1)(eslint@7.32.0)(typescript@5.1.3)
   eslint-plugin-node:
     specifier: ^11.1.0
     version: 11.1.0(eslint@7.32.0)
@@ -87,19 +87,19 @@ devDependencies:
     version: 5.0.1
   tailwindcss:
     specifier: ^3.2.7
-    version: 3.2.7(postcss@8.4.21)(ts-node@10.9.1)
+    version: 3.2.7(postcss@8.4.24)(ts-node@10.9.1)
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.1(@swc/core@1.2.198)(@types/node@18.11.18)(typescript@4.9.5)
+    version: 10.9.1(@swc/core@1.2.198)(@types/node@18.11.18)(typescript@5.1.3)
   tslib:
     specifier: ^2.4.1
     version: 2.4.1
   tsup:
     specifier: 6.6.3
-    version: 6.6.3(@swc/core@1.2.198)(postcss@8.4.21)(ts-node@10.9.1)(typescript@4.9.5)
+    version: 6.6.3(@swc/core@1.2.198)(postcss@8.4.24)(ts-node@10.9.1)(typescript@5.1.3)
   typescript:
-    specifier: 4.9.5
-    version: 4.9.5
+    specifier: 5.1.3
+    version: 5.1.3
   webpack:
     specifier: ^5.53.0
     version: 5.75.0(@swc/core@1.2.198)(esbuild@0.17.11)
@@ -1311,7 +1311,7 @@ packages:
       '@swc/core': 1.2.198
     dev: true
 
-  /@swc-node/jest@1.5.6(@swc/core@1.2.198)(typescript@4.9.5):
+  /@swc-node/jest@1.5.6(@swc/core@1.2.198)(typescript@5.1.3):
     resolution: {integrity: sha512-znW8hxrvEyuaPhkAUBn+zCY53WnE0WKNb1jPNSW+QwBOwQz7wdQn/nTRTojeFyqmGxlJNgxyVVKMx+n9xnrq8Q==}
     peerDependencies:
       '@swc/core': '>= 1.3'
@@ -1319,14 +1319,14 @@ packages:
     dependencies:
       '@node-rs/xxhash': 1.3.0
       '@swc-node/core': 1.9.2(@swc/core@1.2.198)
-      '@swc-node/register': 1.5.5(@swc/core@1.2.198)(typescript@4.9.5)
+      '@swc-node/register': 1.5.5(@swc/core@1.2.198)(typescript@5.1.3)
       '@swc/core': 1.2.198
-      typescript: 4.9.5
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@swc-node/register@1.5.5(@swc/core@1.2.198)(typescript@4.9.5):
+  /@swc-node/register@1.5.5(@swc/core@1.2.198)(typescript@5.1.3):
     resolution: {integrity: sha512-SNpbRG8EOXShk3YAnC4suAVovYQ7oFOFdCVBA3J8hkO5qy0WHPVnlnMojTYI+8UT1CrfQ1QSUySaAARRvEdwjg==}
     peerDependencies:
       '@swc/core': '>= 1.3'
@@ -1339,7 +1339,7 @@ packages:
       debug: 4.3.4
       pirates: 4.0.5
       tslib: 2.4.1
-      typescript: 4.9.5
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1650,7 +1650,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.48.1(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@4.9.5):
+  /@typescript-eslint/eslint-plugin@5.48.1(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@5.1.3):
     resolution: {integrity: sha512-9nY5K1Rp2ppmpb9s9S2aBiF3xo5uExCehMDmYmmFqqyxgenbHJ3qbarcLt4ITgaD6r/2ypdlcFRdcuVPnks+fQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1661,18 +1661,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.48.1(eslint@7.32.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.48.1(eslint@7.32.0)(typescript@5.1.3)
       '@typescript-eslint/scope-manager': 5.48.1
-      '@typescript-eslint/type-utils': 5.48.1(eslint@7.32.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.48.1(eslint@7.32.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 5.48.1(eslint@7.32.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.48.1(eslint@7.32.0)(typescript@5.1.3)
       debug: 4.3.4
       eslint: 7.32.0
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1706,7 +1706,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@4.9.5):
+  /@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@5.1.3):
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1715,7 +1715,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 4.33.0(typescript@5.1.3)
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@7.32.0)
@@ -1758,7 +1758,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.48.1(eslint@7.32.0)(typescript@4.9.5):
+  /@typescript-eslint/parser@5.48.1(eslint@7.32.0)(typescript@5.1.3):
     resolution: {integrity: sha512-4yg+FJR/V1M9Xoq56SF9Iygqm+r5LMXvheo6DQ7/yUWynQ4YfCRnsKuRgqH4EQ5Ya76rVwlEpw4Xu+TgWQUcdA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1770,10 +1770,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.48.1
       '@typescript-eslint/types': 5.48.1
-      '@typescript-eslint/typescript-estree': 5.48.1(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.48.1(typescript@5.1.3)
       debug: 4.3.4
       eslint: 7.32.0
-      typescript: 4.9.5
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1794,7 +1794,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.48.1
     dev: true
 
-  /@typescript-eslint/type-utils@5.48.1(eslint@7.32.0)(typescript@4.9.5):
+  /@typescript-eslint/type-utils@5.48.1(eslint@7.32.0)(typescript@5.1.3):
     resolution: {integrity: sha512-Hyr8HU8Alcuva1ppmqSYtM/Gp0q4JOp1F+/JH5D1IZm/bUBrV0edoewQZiEc1r6I8L4JL21broddxK8HAcZiqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1804,12 +1804,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.48.1(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.48.1(eslint@7.32.0)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.48.1(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.48.1(eslint@7.32.0)(typescript@5.1.3)
       debug: 4.3.4
       eslint: 7.32.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1859,7 +1859,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@4.33.0(typescript@4.9.5):
+  /@typescript-eslint/typescript-estree@4.33.0(typescript@5.1.3):
     resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -1874,13 +1874,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.48.1(typescript@4.9.5):
+  /@typescript-eslint/typescript-estree@5.48.1(typescript@5.1.3):
     resolution: {integrity: sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1895,13 +1895,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.48.1(eslint@7.32.0)(typescript@4.9.5):
+  /@typescript-eslint/utils@5.48.1(eslint@7.32.0)(typescript@5.1.3):
     resolution: {integrity: sha512-SmQuSrCGUOdmGMwivW14Z0Lj8dxG1mOFZ7soeJ0TQZEJcs3n5Ndgkg0A4bcMFzBELqLJ6GTHnEU+iIoaD6hFGA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1911,7 +1911,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.48.1
       '@typescript-eslint/types': 5.48.1
-      '@typescript-eslint/typescript-estree': 5.48.1(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.48.1(typescript@5.1.3)
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@7.32.0)
@@ -3077,7 +3077,7 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-config-ts-lambdas@1.2.3(@typescript-eslint/eslint-plugin@5.48.1)(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@4.9.5):
+  /eslint-config-ts-lambdas@1.2.3(@typescript-eslint/eslint-plugin@5.48.1)(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@5.1.3):
     resolution: {integrity: sha512-fVAVTza+i3GIE3g+QScGPEbbbJDJhwGi0bhGUrMri9tAdZHPiXdAJ/MGrp67kwMyRS8t3a/P2PLxFCPcmJSEbA==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '>=1.6.0'
@@ -3085,10 +3085,10 @@ packages:
       eslint: '>5.0.0'
       typescript: '>3.1.0'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.48.1(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.48.1(eslint@7.32.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.48.1(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.48.1(eslint@7.32.0)(typescript@5.1.3)
       eslint: 7.32.0
-      typescript: 4.9.5
+      typescript: 5.1.3
     dev: true
 
   /eslint-import-resolver-node@0.3.7:
@@ -3157,7 +3157,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.48.1(eslint@7.32.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.48.1(eslint@7.32.0)(typescript@5.1.3)
       debug: 3.2.7
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.7
@@ -3187,7 +3187,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.48.1(eslint@7.32.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.48.1(eslint@7.32.0)(typescript@5.1.3)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -3210,7 +3210,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@5.48.1)(eslint@7.32.0)(typescript@4.9.5):
+  /eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@5.48.1)(eslint@7.32.0)(typescript@5.1.3):
     resolution: {integrity: sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -3220,8 +3220,8 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.48.1(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@4.9.5)
-      '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.48.1(@typescript-eslint/parser@5.48.1)(eslint@7.32.0)(typescript@5.1.3)
+      '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.1.3)
       eslint: 7.32.0
     transitivePeerDependencies:
       - supports-color
@@ -4337,7 +4337,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.2.198)(@types/node@18.11.18)(typescript@4.9.5)
+      ts-node: 10.9.1(@swc/core@1.2.198)(@types/node@18.11.18)(typescript@5.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4939,7 +4939,7 @@ packages:
     resolution: {integrity: sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==}
     hasBin: true
     optionalDependencies:
-      minimist: 1.2.7
+      minimist: 1.2.8
     dev: true
 
   /makeerror@1.0.12:
@@ -5055,6 +5055,12 @@ packages:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
     dev: true
 
+  /minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -5082,8 +5088,8 @@ packages:
       thenify-all: 1.6.0
     dev: true
 
-  /nanoid@3.3.4:
-    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+  /nanoid@3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
@@ -5356,29 +5362,29 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /postcss-import@14.1.0(postcss@8.4.21):
+  /postcss-import@14.1.0(postcss@8.4.24):
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.21
+      postcss: 8.4.24
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.1
     dev: true
 
-  /postcss-js@4.0.0(postcss@8.4.21):
+  /postcss-js@4.0.0(postcss@8.4.24):
     resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.3.3
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.21
+      postcss: 8.4.24
     dev: true
 
-  /postcss-load-config@3.1.4(postcss@8.4.21)(ts-node@10.9.1):
+  /postcss-load-config@3.1.4(postcss@8.4.24)(ts-node@10.9.1):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -5391,18 +5397,18 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.6
-      postcss: 8.4.21
-      ts-node: 10.9.1(@swc/core@1.2.198)(@types/node@18.11.18)(typescript@4.9.5)
+      postcss: 8.4.24
+      ts-node: 10.9.1(@swc/core@1.2.198)(@types/node@18.11.18)(typescript@5.1.3)
       yaml: 1.10.2
     dev: true
 
-  /postcss-nested@6.0.0(postcss@8.4.21):
+  /postcss-nested@6.0.0(postcss@8.4.24):
     resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.21
+      postcss: 8.4.24
       postcss-selector-parser: 6.0.11
     dev: true
 
@@ -5418,11 +5424,11 @@ packages:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
-  /postcss@8.4.21:
-    resolution: {integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==}
+  /postcss@8.4.24:
+    resolution: {integrity: sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.4
+      nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: true
@@ -6171,11 +6177,11 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /tailwind-merge@1.10.0:
-    resolution: {integrity: sha512-WFnDXSS4kFTZwjKg5/oZSGzBRU/l+qcbv5NVTzLUQvJ9yovDAP05h0F2+ZFW0Lw9EcgRoc2AfURUdZvnEFrXKg==}
+  /tailwind-merge@1.13.2:
+    resolution: {integrity: sha512-R2/nULkdg1VR/EL4RXg4dEohdoxNUJGLMnWIQnPKL+O9Twu7Cn3Rxi4dlXkDzZrEGtR+G+psSXFouWlpTyLhCQ==}
     dev: false
 
-  /tailwindcss@3.2.7(postcss@8.4.21)(ts-node@10.9.1):
+  /tailwindcss@3.2.7(postcss@8.4.24)(ts-node@10.9.1):
     resolution: {integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -6196,11 +6202,11 @@ packages:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.21
-      postcss-import: 14.1.0(postcss@8.4.21)
-      postcss-js: 4.0.0(postcss@8.4.21)
-      postcss-load-config: 3.1.4(postcss@8.4.21)(ts-node@10.9.1)
-      postcss-nested: 6.0.0(postcss@8.4.21)
+      postcss: 8.4.24
+      postcss-import: 14.1.0(postcss@8.4.24)
+      postcss-js: 4.0.0(postcss@8.4.24)
+      postcss-load-config: 3.1.4(postcss@8.4.24)(ts-node@10.9.1)
+      postcss-nested: 6.0.0(postcss@8.4.24)
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
@@ -6375,6 +6381,38 @@ packages:
       yn: 3.1.1
     dev: true
 
+  /ts-node@10.9.1(@swc/core@1.2.198)(@types/node@18.11.18)(typescript@5.1.3):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@swc/core': 1.2.198
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 18.11.18
+      acorn: 8.8.1
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.1.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /tsconfig-paths@3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -6392,7 +6430,7 @@ packages:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
     dev: true
 
-  /tsup@6.6.3(@swc/core@1.2.198)(postcss@8.4.21)(ts-node@10.9.1)(typescript@4.9.5):
+  /tsup@6.6.3(@swc/core@1.2.198)(postcss@8.4.24)(ts-node@10.9.1)(typescript@5.1.3):
     resolution: {integrity: sha512-OLx/jFllYlVeZQ7sCHBuRVEQBBa1tFbouoc/gbYakyipjVQdWy/iQOvmExUA/ewap9iQ7tbJf9pW0PgcEFfJcQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -6417,14 +6455,14 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss: 8.4.21
-      postcss-load-config: 3.1.4(postcss@8.4.21)(ts-node@10.9.1)
+      postcss: 8.4.24
+      postcss-load-config: 3.1.4(postcss@8.4.24)(ts-node@10.9.1)
       resolve-from: 5.0.0
       rollup: 3.10.0
       source-map: 0.8.0-beta.0
       sucrase: 3.29.0
       tree-kill: 1.2.2
-      typescript: 4.9.5
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -6440,14 +6478,14 @@ packages:
       typescript: 3.9.10
     dev: true
 
-  /tsutils@3.21.0(typescript@4.9.5):
+  /tsutils@3.21.0(typescript@5.1.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.5
+      typescript: 5.1.3
     dev: true
 
   /type-check@0.3.2:
@@ -6511,6 +6549,12 @@ packages:
   /typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.1.3:
+    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -214,7 +214,16 @@ export type TV = {
     B extends ClassValue = undefined,
     S extends TVSlots = undefined,
     // @ts-expect-error
-    E extends TVReturnType = undefined,
+    E extends TVReturnType = TVReturnType<
+      V,
+      S,
+      B,
+      C,
+      // @ts-expect-error
+      EV extends undefined ? {} : EV,
+      // @ts-expect-error
+      ES extends undefined ? {} : ES
+    >,
     EV extends TVVariants<ES, B, E["variants"], ES> = E["variants"],
     ES extends TVSlots = E["slots"] extends TVSlots ? E["slots"] : undefined,
   >(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -215,8 +215,7 @@ export type TV = {
     S extends TVSlots = undefined,
     // @ts-expect-error
     E extends TVReturnType = undefined,
-    // @ts-expect-error
-    EV extends TVVariants = E["variants"] extends TVVariants ? E["variants"] : undefined,
+    EV extends TVVariants<ES, B, E["variants"], ES> = E["variants"],
     ES extends TVSlots = E["slots"] extends TVSlots ? E["slots"] : undefined,
   >(
     options: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

closes: https://github.com/nextui-org/tailwind-variants/issues/59
closes: https://github.com/nextui-org/tailwind-variants/issues/56
closes: https://github.com/nextui-org/tailwind-variants/issues/55
closes: https://github.com/nextui-org/tailwind-variants/issues/53

### Description

- Add generics to `EV` and `TVReturnType` for type inference.

### Additional context

- Upgrade `tailwind-merge` to the latest version.
- Upgrade `typescript` to the latest version.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
