### PR TITLE
fix: default config assigned to the config prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ export const cnBase = (...classes) => voidEmpty(classes.flat(Infinity).filter(Bo
 
 export const cn =
   (...classes) =>
-  (config = defaultConfig) => {
+  (config) => {
     if (!config.twMerge) {
       return cnBase(classes);
     }
@@ -46,7 +46,7 @@ const joinObjects = (obj1, obj2) => {
   return mergedObj;
 };
 
-export const tv = (options, config = defaultConfig) => {
+export const tv = (options, configProp) => {
   const {
     slots: slotProps = {},
     variants: variantsProps = {},
@@ -54,6 +54,8 @@ export const tv = (options, config = defaultConfig) => {
     compoundSlots = [],
     defaultVariants: defaultVariantsProps = {},
   } = options;
+
+  const config = Object.assign({}, defaultConfig, configProp);
 
   const base = cnBase(options?.extend?.base, options?.base);
   const variants = mergeObjects(variantsProps, options?.extend?.variants);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #64 
Closes #58 


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Tailwind merge was disabled when custom tw-merge config passed

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
