### PR TITLE
feat: Add support for slot level variant overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
       "esm"
     ]
   },
-  "packageManager": "pnpm@8.3.1",
+  "packageManager": "pnpm@8.6.8",
   "engines": {
     "node": ">=16.x",
     "pnpm": ">=7.x"

--- a/src/__tests__/tv.test.ts
+++ b/src/__tests__/tv.test.ts
@@ -691,6 +691,119 @@ describe("Tailwind Variants (TV) - Slots", () => {
     expectTv(list(), ["list-none", "color--secondary-list", "compound--list"]);
     expectTv(wrapper(), ["flex", "flex-col", "color--secondary-wrapper", "compound--wrapper"]);
   });
+
+  test("should support slot level variant overrides", () => {
+    const menu = tv({
+      base: "text-3xl",
+      slots: {
+        title: "text-2xl",
+      },
+      variants: {
+        color: {
+          primary: {
+            base: "color--primary-base",
+            title: "color--primary-title",
+          },
+          secondary: {
+            base: "color--secondary-base",
+            title: "color--secondary-title",
+          },
+        },
+      },
+      defaultVariants: {
+        color: "primary",
+      },
+    });
+
+    const {base, title} = menu();
+
+    expectTv(base(), ["text-3xl", "color--primary-base"]);
+    expectTv(title(), ["text-2xl", "color--primary-title"]);
+    expectTv(base({color: "secondary"}), ["text-3xl", "color--secondary-base"]);
+    expectTv(title({color: "secondary"}), ["text-2xl", "color--secondary-title"]);
+  });
+
+  test("should support slot level variant overrides - compoundSlots", () => {
+    const menu = tv({
+      base: "text-3xl",
+      slots: {
+        title: "text-2xl",
+        subtitle: "text-xl",
+      },
+      variants: {
+        color: {
+          primary: {
+            base: "color--primary-base",
+            title: "color--primary-title",
+            subtitle: "color--primary-subtitle",
+          },
+          secondary: {
+            base: "color--secondary-base",
+            title: "color--secondary-title",
+            subtitle: "color--secondary-subtitle",
+          },
+        },
+      },
+      compoundSlots: [
+        {
+          slots: ["title", "subtitle"],
+          color: "secondary",
+          class: ["truncate"],
+        },
+      ],
+      defaultVariants: {
+        color: "primary",
+      },
+    });
+
+    const {base, title, subtitle} = menu();
+
+    expectTv(base(), ["text-3xl", "color--primary-base"]);
+    expectTv(title(), ["text-2xl", "color--primary-title"]);
+    expectTv(subtitle(), ["text-xl", "color--primary-subtitle"]);
+    expectTv(base({color: "secondary"}), ["text-3xl", "color--secondary-base"]);
+    expectTv(title({color: "secondary"}), ["text-2xl", "color--secondary-title", "truncate"]);
+    expectTv(subtitle({color: "secondary"}), ["text-xl", "color--secondary-subtitle", "truncate"]);
+  });
+
+  test("should support slot level variant overrides - compoundVariants", () => {
+    const menu = tv({
+      base: "text-3xl",
+      slots: {
+        title: "text-2xl",
+      },
+      variants: {
+        color: {
+          primary: {
+            base: "color--primary-base",
+            title: "color--primary-title",
+          },
+          secondary: {
+            base: "color--secondary-base",
+            title: "color--secondary-title",
+          },
+        },
+      },
+      compoundVariants: [
+        {
+          color: "secondary",
+          class: {
+            title: "truncate",
+          },
+        },
+      ],
+      defaultVariants: {
+        color: "primary",
+      },
+    });
+
+    const {base, title} = menu();
+
+    expectTv(base(), ["text-3xl", "color--primary-base"]);
+    expectTv(title(), ["text-2xl", "color--primary-title"]);
+    expectTv(base({color: "secondary"}), ["text-3xl", "color--secondary-base"]);
+    expectTv(title({color: "secondary"}), ["text-2xl", "color--secondary-title", "truncate"]);
+  });
 });
 
 describe("Tailwind Variants (TV) - Compound Slots", () => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -206,8 +206,8 @@ export type TVReturnType<
   (props?: TVProps<V, S, C, EV, ES>): ES extends undefined
     ? S extends undefined
       ? string
-      : {[K in TVSlotsWithBase<S, B>]: (slotProps?: ClassProp) => string}
-    : {[K in TVSlotsWithBase<ES & S, B>]: (slotProps?: ClassProp) => string};
+      : {[K in TVSlotsWithBase<S, B>]: (slotProps?: TVProps<V, S, C, EV, ES>) => string}
+    : {[K in TVSlotsWithBase<ES & S, B>]: (slotProps?: TVProps<V, S, C, EV, ES>) => string};
 } & TVReturnProps<V, S, B, EV, ES, E>;
 
 export type TV = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,21 +24,27 @@ export function flatArray(arr) {
 export const flatMergeArrays = (...arrays) => flatArray(arrays).filter(Boolean);
 
 export const mergeObjects = (obj1, obj2) => {
-  let result = {};
+  const result = {};
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
 
-  for (let key in obj1) {
-    if (obj2?.hasOwnProperty(key)) {
-      result[key] =
-        typeof obj1[key] === "object"
-          ? mergeObjects(obj1[key], obj2[key])
-          : obj2[key] + " " + obj1[key];
+  for (const key of keys1) {
+    if (keys2.includes(key)) {
+      const val1 = obj1[key];
+      const val2 = obj2[key];
+
+      if (typeof val1 === "object" && typeof val2 === "object") {
+        result[key] = mergeObjects(val1, val2);
+      } else {
+        result[key] = val2 + " " + val1;
+      }
     } else {
       result[key] = obj1[key];
     }
   }
 
-  for (let key in obj2) {
-    if (!result.hasOwnProperty(key)) {
+  for (const key of keys2) {
+    if (!keys1.includes(key)) {
       result[key] = obj2[key];
     }
   }


### PR DESCRIPTION
Fixes #48 

### Description

This adds support for slot level variant overrides. This is useful in a variety of situations:

1. Component libraries that provide slot level class name functions:
   ```typescript
   const {base,tab} = tv({...})
 
   <Tabs className={() => base()}>
     <Tab className={({ isSelected }) => tab({isSelected})}>
       Settings
     </Tab>
   </Tabs>
   ```
1. Reusing styles for vary similar components.
	```typescript
	const {base,item} = tv({...})
	
    <Nav className={base()}>
	  <NavItem className={item({isActive: activeItem === 'foo'})}>foo</NavItem>
      <NavItem className={item({isActive: activeItem === 'bar'})}>bar</NavItem>
    </Nav>
	```

### Additional context

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
