### PR TITLE
fix: support `false` variants when using `compoundSlots`

### DIFF
--- a/src/__tests__/tv.test.ts
+++ b/src/__tests__/tv.test.ts
@@ -842,14 +842,14 @@ describe("Tailwind Variants (TV) - Compound Slots", () => {
           slots: ["item", "prev", "next"],
           size: "xs",
           color: "primary",
-          isBig: true,
+          isBig: false,
           class: "w-7 h-7 text-xs",
         },
       ],
       defaultVariants: {
         size: "xs",
         color: "primary",
-        isBig: true,
+        isBig: false,
       },
     });
     // with default values

--- a/src/index.js
+++ b/src/index.js
@@ -304,7 +304,7 @@ export const tv = (options, configProp) => {
 
             // if none of the slot variant keys are included in props or default variants then skip the slot
             // if the included slot variant key is not equal to the slot variant value then skip the slot
-            if (!completePropsValue || completePropsValue !== slotVariants[key]) {
+            if (completePropsValue === undefined || completePropsValue !== slotVariants[key]) {
               return acc;
             }
           }


### PR DESCRIPTION
Fixes #74 

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`compoundSlots` did not work properly when setting a boolean variant to `false`. This resolves that issue.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
