### PR TITLE
fix: align class value with tailwind-merge

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+import type {ClassNameValue as ClassValue} from "tailwind-merge";
+
 import {TVConfig, TWMConfig} from "./config";
 import {TVGeneratedScreens} from "./generated";
 
@@ -7,7 +9,7 @@ import {TVGeneratedScreens} from "./generated";
  * ----------------------------------------
  */
 
-export type ClassValue = string | string[] | null | undefined | ClassValue[];
+export type {ClassValue};
 
 export type ClassProp<V extends unknown = ClassValue> =
   | {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR aligns the `ClassValue` type with with corresponding type from `tailwind-merge`. In particular, the old type was missing `0` and `false` as possible values. This makes it difficult to use tailwind-merge + tailwind-variants together since the base class typing is different between the two projects.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix (kind of?)
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
