### PR TITLE
fix: prevented writeFileSync from being called on client side

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -1,7 +1,7 @@
-import fs from "fs";
-import path from "path";
-
 const writeFileSync = (content) => {
+  const fs = require("fs");
+  const path = require("path");
+
   fs.writeFileSync(path.join(__dirname, "generated.d.ts"), content);
 };
 
@@ -16,7 +16,9 @@ export const generateTypes = (theme) => {
     if (theme?.screens) {
       const screens = generateScreensType(theme.screens);
 
-      writeFileSync(screens);
+      if (typeof window === "undefined") {
+        writeFileSync(screens);
+      }
     }
   });
 };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- close: #90 

<!--

この PR は、モノレポ (e.g. turborepo) において子パッケージ内で `withTV()` を使用した場合に発生するエラーを修正するものです。

#90 内の補足で説明した通り、親パッケージの `tailwind.config.ts` で `withTV()` を使用すれば問題は起きません。
しかし、 `withTV()` を子パッケージに隠蔽したいという需要は少なからずあると私は思っています。

お手すきの際にご確認いただけますと幸いです。
よろしくお願いします。

-->

This PR fixes an error that occurs when using `withTV()` in a child package in monorepo (e.g. turborepo).

As explained in the supplement in #90, using `withTV()` in `tailwind.config.ts` of the parent package will not cause problems.
However, I believe there is a small demand to hide `withTV()` in the child package.

I would appreciate it if you could check this out when you are available.

<!-- ### Additional context -->

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
