### PR TITLE
fix: prevent extend from modifying extended slots

### DIFF
--- a/src/__tests__/tv.test.ts
+++ b/src/__tests__/tv.test.ts
@@ -2200,13 +2200,21 @@ describe("Tailwind Variants (TV) - Extends", () => {
     });
 
     // with default values
-    const {base, title, item, list, wrapper} = menu();
+    let res = menu();
 
-    expectTv(base(), ["base--menuBase", "base--menu"]);
-    expectTv(title(), ["title--menuBase", "title--menu"]);
-    expectTv(item(), ["item--menuBase", "item--menu"]);
-    expectTv(list(), ["list--menuBase", "list--menu"]);
-    expectTv(wrapper(), ["wrapper--menuBase", "wrapper--menu"]);
+    expectTv(res.base(), ["base--menuBase", "base--menu"]);
+    expectTv(res.title(), ["title--menuBase", "title--menu"]);
+    expectTv(res.item(), ["item--menuBase", "item--menu"]);
+    expectTv(res.list(), ["list--menuBase", "list--menu"]);
+    expectTv(res.wrapper(), ["wrapper--menuBase", "wrapper--menu"]);
+
+    res = menuBase();
+
+    expect(res.base()).toBe("base--menuBase");
+    expect(res.title()).toBe("title--menuBase");
+    expect(res.item()).toBe("item--menuBase");
+    expect(res.list()).toBe("list--menuBase");
+    expect(res.wrapper()).toBe("wrapper--menuBase");
   });
 
   test("should include the extended slots w/ children slots (additional)", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ export const tv = (options, configProp) => {
   const slots = isEmptyObject(extend?.slots)
     ? componentSlots
     : joinObjects(
-        extend?.slots,
+        {...extend?.slots},
         isEmptyObject(componentSlots) ? {base: options?.base} : componentSlots,
       );
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #104 

The change to `joinObjects` was causing extended slots to be mutated incorrectly.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
