### PR TITLE
feat: support goto definition for slots

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -195,6 +195,12 @@ export type TVReturnProps<
   variantKeys: TVVariantKeys<V, S>;
 };
 
+type HasSlots<S extends TVSlots, ES extends TVSlots> = S extends undefined
+  ? ES extends undefined
+    ? false
+    : true
+  : true;
+
 export type TVReturnType<
   V extends TVVariants<S>,
   S extends TVSlots,
@@ -205,11 +211,19 @@ export type TVReturnType<
   // @ts-expect-error
   E extends TVReturnType = undefined,
 > = {
-  (props?: TVProps<V, S, C, EV, ES>): ES extends undefined
-    ? S extends undefined
-      ? string
-      : {[K in TVSlotsWithBase<S, B>]: (slotProps?: TVProps<V, S, C, EV, ES>) => string}
-    : {[K in TVSlotsWithBase<ES & S, B>]: (slotProps?: TVProps<V, S, C, EV, ES>) => string};
+  (props?: TVProps<V, S, C, EV, ES>): HasSlots<S, ES> extends true
+    ? {
+        [K in keyof (ES extends undefined ? {} : ES)]: (
+          slotProps?: TVProps<V, S, C, EV, ES>,
+        ) => string;
+      } & {
+        [K in keyof (S extends undefined ? {} : S)]: (
+          slotProps?: TVProps<V, S, C, EV, ES>,
+        ) => string;
+      } & {
+        [K in TVSlotsWithBase<{}, B>]: (slotProps?: TVProps<V, S, C, EV, ES>) => string;
+      }
+    : string;
 } & TVReturnProps<V, S, B, EV, ES, E>;
 
 export type TV = {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This reworks `TVReturnType` to use `keyof` on the original generic objects so that go to definition will work properly on slots.

I'm trying to get the same to work for `base`, but that one's a little more complex since that will require some amount of shifting the options into a generic of it's own which has some complexities.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


https://github.com/nextui-org/tailwind-variants/assets/25914066/c72599d0-af10-416d-945c-e8128e54e9e3

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
