### PR TITLE
feat: add `createTV` utility to create a `tv` function from a config

### DIFF
--- a/src/__tests__/createTV.test.ts
+++ b/src/__tests__/createTV.test.ts
@@ -1,0 +1,20 @@
+import {createTV} from "../index";
+
+describe("createTV", () => {
+  test("should use config in tv calls", () => {
+    const tv = createTV({twMerge: false});
+    const h1 = tv({base: "text-3xl font-bold text-blue-400 text-xl text-blue-200"});
+
+    expect(h1()).toBe("text-3xl font-bold text-blue-400 text-xl text-blue-200");
+  });
+
+  test("should override config", () => {
+    const tv = createTV({twMerge: false});
+    const h1 = tv(
+      {base: "text-3xl font-bold text-blue-400 text-xl text-blue-200"},
+      {twMerge: true},
+    );
+
+    expect(h1()).toBe("font-bold text-xl text-blue-200");
+  });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -296,6 +296,8 @@ export type TV = {
 // main function
 export declare const tv: TV;
 
+export declare function createTV(config: TVConfig): TV;
+
 export declare const defaultConfig: TVConfig;
 
 export type VariantProps<Component extends (...args: any) => any> = Omit<

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ import {
   removeExtraSpaces,
   flatMergeArrays,
   flatArray,
-  isBoolean,
 } from "./utils.js";
 
 export const defaultConfig = {
@@ -426,4 +425,8 @@ export const tv = (options, configProp) => {
   component.compoundVariants = compoundVariants;
 
   return component;
+};
+
+export const createTV = (configProp) => {
+  return (options, config) => tv(options, config ? mergeObjects(configProp, config) : configProp);
 };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This adds a new `createTV` function that allows users to create a configured version of `tv` with tailwind-merge or other config. This is similar to using `defaultConfig` but supports multiple separate `tv` functions.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Fixes https://github.com/nextui-org/tailwind-variants/issues/95
Fixes https://github.com/nextui-org/tailwind-variants/issues/18

Docs PR here: https://github.com/nextui-org/tailwind-variants-docs/pull/19

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
