### PR TITLE
fix: variant as array when extending

### DIFF
--- a/src/__tests__/tv.test.ts
+++ b/src/__tests__/tv.test.ts
@@ -1938,7 +1938,7 @@ describe("Tailwind Variants (TV) - Extends", () => {
           false: "text-2xl",
         },
         color: {
-          red: "text-red-500 bg-red-100",
+          red: "text-red-500 bg-red-100 tracking-normal",
           blue: "text-blue-500",
         },
       },
@@ -1949,7 +1949,7 @@ describe("Tailwind Variants (TV) - Extends", () => {
       base: "text-3xl font-bold",
       variants: {
         color: {
-          red: "text-red-200",
+          red: ["text-red-200", "bg-red-200"],
           green: "text-green-500",
         },
       },
@@ -1960,7 +1960,13 @@ describe("Tailwind Variants (TV) - Extends", () => {
       color: "red",
     });
 
-    const expectedResult = ["font-bold", "text-red-200", "bg-red-100", "text-5xl"];
+    const expectedResult = [
+      "font-bold",
+      "text-red-200",
+      "bg-red-200",
+      "tracking-normal",
+      "text-5xl",
+    ];
 
     expectTv(result, expectedResult);
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,6 +37,8 @@ export const mergeObjects = (obj1, obj2) => {
 
       if (typeof val1 === "object" && typeof val2 === "object") {
         result[key] = mergeObjects(val1, val2);
+      } else if (Array.isArray(val1) || Array.isArray(val2)) {
+        result[key] = flatMergeArrays(val2, val1);
       } else {
         result[key] = val2 + " " + val1;
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes the `mergeObjects` function that was only allowing string for variants.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

When using the `extend` property, it's used the function `mergeObjects` but it doesn't handle array inputs only string.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
