### PR TITLE
fix: prevent optional chaining operator bug by upgrading to tailwind-merge v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "jest --verbose"
   },
   "dependencies": {
-    "tailwind-merge": "^1.14.0"
+    "tailwind-merge": "^2.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.2.0",
@@ -49,6 +49,7 @@
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
+    "benchmark": "2.1.4",
     "clean-package": "2.1.1",
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.2.0",
@@ -69,8 +70,7 @@
     "tslib": "^2.4.1",
     "tsup": "6.6.3",
     "typescript": "5.1.3",
-    "webpack": "^5.53.0",
-    "benchmark": "2.1.4"
+    "webpack": "^5.53.0"
   },
   "peerDependencies": {
     "tailwindcss": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   tailwind-merge:
-    specifier: ^1.14.0
-    version: 1.14.0
+    specifier: ^2.0.0
+    version: 2.0.0
 
 devDependencies:
   '@commitlint/cli':
@@ -404,6 +404,13 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
+
+  /@babel/runtime@7.23.4:
+    resolution: {integrity: sha512-2Yv65nlWnWlSpe3fXEyX5i7fx5kIKo4Qbcj+hMO0odwaneFjfXw5fdum+4yL20O0QiaHpia0cYQ9xpNMqrBwHg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.0
+    dev: false
 
   /@babel/template@7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
@@ -5669,6 +5676,10 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
+  /regenerator-runtime@0.14.0:
+    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
+    dev: false
+
   /regexp.prototype.flags@1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
@@ -6191,8 +6202,10 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /tailwind-merge@1.14.0:
-    resolution: {integrity: sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==}
+  /tailwind-merge@2.0.0:
+    resolution: {integrity: sha512-WO8qghn9yhsldLSg80au+3/gY9E4hFxIvQ3qOmlpXnqpDKoMruKfi/56BbbMg6fHTQJ9QD3cc79PoWqlaQE4rw==}
+    dependencies:
+      '@babel/runtime': 7.23.4
     dev: false
 
   /tailwindcss@3.2.7(postcss@8.4.24)(ts-node@10.9.1):

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -14,7 +14,7 @@ export type TWMConfig = {
    * The config object for `tailwind-merge` library.
    * @see https://github.com/dcastil/tailwind-merge/blob/v1.8.1/docs/configuration.md
    */
-  twMergeConfig?: Partial<TwMergeConfig>;
+  twMergeConfig?: Partial<TwMergeConfig<never, never>>;
 };
 
 export type TVConfig<

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -14,7 +14,7 @@ export type TWMConfig = {
    * The config object for `tailwind-merge` library.
    * @see https://github.com/dcastil/tailwind-merge/blob/v1.8.1/docs/configuration.md
    */
-  twMergeConfig?: Partial<TwMergeConfig<never, never>>;
+  twMergeConfig?: Partial<TwMergeConfig<string, string>>;
 };
 
 export type TVConfig<

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import {twMerge as twMergeBase, extendTailwindMerge} from "tailwind-merge";
+import {extendTailwindMerge} from "tailwind-merge";
+import {twMerge as twMergeBase} from "tailwind-merge/es5";
 
 import {
   isEqual,
@@ -35,7 +36,7 @@ export const cn =
       didTwMergeConfigChange = false;
       cachedTwMerge = isEmptyObject(cachedTwMergeConfig)
         ? twMergeBase
-        : extendTailwindMerge(cachedTwMergeConfig);
+        : extendTailwindMerge({extend: cachedTwMergeConfig});
     }
 
     return voidEmpty(cachedTwMerge(cnBase(classes)));


### PR DESCRIPTION
### Description

Fixes https://github.com/nextui-org/tailwind-variants/issues/128

In certain runtimes, the optional chaining operator (`?`) does not exist, and throws errors. We frequently see this on older browsers in our Next.js app running `tailwind-variants` in the client.

### What is the purpose of this pull request?

Upgrades [tailwind-merge](https://github.com/dcastil/tailwind-merge) to v2 and switches usage to `tailwind-merge/es5` version (only for `twMerge`, not `extendTailwindMerge`) to prevent [optional chaining operator bug](https://github.com/nextui-org/tailwind-variants/issues/128) in certain runtimes (per https://github.com/dcastil/tailwind-merge/issues/344#issuecomment-1809947458).

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [X] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
