### PR TITLE
fix: types of the extend variants

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,11 +62,13 @@ type SlotsClassValue<S extends TVSlots, B extends ClassValue> = {
   [K in TVSlotsWithBase<S, B>]?: ClassValue;
 };
 
-type TVVariantsDefault<S extends TVSlots, B extends ClassValue> = {
-  [key: string]: {
-    [key: string]: S extends TVSlots ? SlotsClassValue<S, B> | ClassValue : ClassValue;
-  };
-};
+type TVVariantsDefault<S extends TVSlots, B extends ClassValue> = S extends undefined
+  ? {}
+  : {
+      [key: string]: {
+        [key: string]: S extends TVSlots ? SlotsClassValue<S, B> | ClassValue : ClassValue;
+      };
+    };
 
 export type TVVariants<
   S extends TVSlots | undefined,
@@ -77,12 +79,11 @@ export type TVVariants<
   ? TVVariantsDefault<S, B>
   :
       | {
-          [K in keyof EV]?:
-            | {
-                [K2 in keyof EV[K]]?: S extends TVSlots
-                  ? SlotsClassValue<S, B> | ClassValue
-                  : ClassValue;
-              };
+          [K in keyof EV]: {
+            [K2 in keyof EV[K]]: S extends TVSlots
+              ? SlotsClassValue<S, B> | ClassValue
+              : ClassValue;
+          };
         }
       | TVVariantsDefault<S, B>;
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Fixes https://github.com/nextui-org/tailwind-variants/issues/15
Fixes https://github.com/nextui-org/tailwind-variants/issues/44


### Description

Fixed types of the extend variants by asserting slots and providing default value (`{}`).

<!-- 
### Additional context

e.g. is there anything you'd like reviewers to focus on?
 -->
---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
