### PR TITLE
fix: allow calling `cn` without passing configuration params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ let didTwMergeConfigChange = false;
 export const cn =
   (...classes) =>
   (config) => {
-    if (!config.twMerge) {
+    if (!config?.twMerge) {
       return cnBase(classes);
     }
 


### PR DESCRIPTION
### Description

Fixes: #157

Currently, using the `cn` utility function without passing any parameters is impossible.

### Additional context

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
