### PR TITLE
fix: Support false-only variant with fallback behaviour

### DIFF
--- a/src/__tests__/tv.test.ts
+++ b/src/__tests__/tv.test.ts
@@ -334,6 +334,42 @@ describe("Tailwind Variants (TV) - Default", () => {
     expect(h1({bool: undefined})).toHaveClass(["text-3xl", "truncate"]);
   });
 
+  test("should support false only variant", () => {
+    const h1 = tv({
+      base: "text-3xl",
+      variants: {
+        bool: {
+          false: "truncate",
+        },
+      },
+    });
+
+    expect(h1()).toHaveClass(["text-3xl", "truncate"]);
+    expect(h1({bool: true})).toHaveClass(["text-3xl"]);
+    expect(h1({bool: false})).toHaveClass(["text-3xl", "truncate"]);
+    expect(h1({bool: undefined})).toHaveClass(["text-3xl", "truncate"]);
+  });
+
+
+  test("should support false only variant -- default variant", () => {
+    const h1 = tv({
+      base: "text-3xl",
+      variants: {
+        bool: {
+          false: "truncate",
+        },
+      },
+      defaultVariants: {
+        bool: true,
+      },
+    });
+
+    expect(h1()).toHaveClass(["text-3xl"]);
+    expect(h1({bool: true})).toHaveClass(["text-3xl"]);
+    expect(h1({bool: false})).toHaveClass(["text-3xl", "truncate"]);
+    expect(h1({bool: undefined})).toHaveClass(["text-3xl"]);
+  });
+
   test("should support boolean variants -- default variants", () => {
     const h1 = tv({
       base: "text-3xl",

--- a/src/index.js
+++ b/src/index.js
@@ -217,7 +217,7 @@ export const tv = (options, configProp) => {
           ? variantKey
           : falsyToString(defaultVariantProp);
 
-      const value = variantObj[key] || variantObj["false"];
+      const value = variantObj[key || "false"];
 
       if (
         typeof screenValues === "object" &&


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

After upgrading to the latest version of `tailwind-variants`, we noticed a small UI regression where a component which specified only a `false` variant was continually using that, despite `true` being specifically passed in.

It looks like this occurs because of the logic to always fall back to the `false` variant if the initial value isn't found:

https://github.com/nextui-org/tailwind-variants/blob/a26d801f13f97af726a0c206ae413cd5543ea7ff/src/index.js#L220

This PR addresses that by changing where the fallback happens. I've also added a couple of tests which cover the case that currently fails.

It's an odd case so hopefully this won't be impacting many other users! In our case, we actually realised that this API choice wasn't ideal and ended up implementing an alternative workaround. Still, the behaviour was very confusing to us for a moment and the fix seems quite simple, so decided to create a PR with the change.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
