### PR TITLE
fix: adjust path for types

### DIFF
--- a/clean-package.config.json
+++ b/clean-package.config.json
@@ -8,7 +8,7 @@
       ".": {
         "require": "./dist/index.cjs",
         "import": "./dist/index.js",
-        "types": "./types/index.d.ts"
+        "types": "./dist/index.d.ts"
       },
       "./dist/*": "./dist/*",
       "./transformer": {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Adjusted the exports types target

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

For projects with `moduleResolution` set to `NodeNext`, `exports` has priority over `types` in `package.json`, as the current types target in `exports` is incorrect, it's currently throwing an error:

<img width="1111" alt="Screenshot 2024-02-24 at 8 04 00 am" src="https://github.com/nextui-org/tailwind-variants/assets/2362138/480f4abc-f2e5-4908-bcbb-ec6891f2aa28">

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
