### PR TITLE
fix mergeObjects order

### DIFF
--- a/src/__tests__/tv.test.ts
+++ b/src/__tests__/tv.test.ts
@@ -2350,6 +2350,115 @@ describe("Tailwind Variants (TV) - Extends", () => {
     expect(result).toHaveClass(expectedResult);
   });
 
+  test.only("should override the extended classes with variants and compoundVariants, using array", () => {
+    const p = tv({
+      base: "text-base text-green-500",
+      variants: {
+        isBig: {
+          true: "text-5xl",
+          false: ["text-2xl"],
+        },
+        color: {
+          red: ["text-red-500 bg-red-100", "tracking-normal"],
+          blue: "text-blue-500",
+        },
+      },
+      defaultVariants: {
+        isBig: true,
+        color: "red",
+      },
+      compoundVariants: [
+        {
+          isBig: true,
+          color: "red",
+          class: "bg-red-500",
+        },
+        {
+          isBig: false,
+          color: "red",
+          class: ["bg-red-500"],
+        },
+        {
+          isBig: true,
+          color: "blue",
+          class: ["bg-blue-500"],
+        },
+        {
+          isBig: false,
+          color: "blue",
+          class: "bg-blue-500",
+        },
+      ],
+    });
+
+    const h1 = tv({
+      extend: p,
+      base: "text-3xl font-bold",
+      variants: {
+        isBig: {
+          true: "text-7xl",
+          false: "text-3xl",
+        },
+        color: {
+          red: ["text-red-200", "bg-red-200"],
+          green: ["text-green-500"],
+        },
+      },
+      compoundVariants: [
+        {
+          isBig: true,
+          color: "red",
+          class: "bg-red-600",
+        },
+        {
+          isBig: false,
+          color: "red",
+          class: "bg-red-600",
+        },
+        {
+          isBig: true,
+          color: "blue",
+          class: ["bg-blue-600"],
+        },
+        {
+          isBig: false,
+          color: "blue",
+          class: ["bg-blue-600"],
+        },
+      ],
+    });
+
+    expect(h1({isBig: true, color: "red"})).toHaveClass([
+      "font-bold",
+      "text-red-200",
+      "bg-red-600",
+      "tracking-normal",
+      "text-7xl",
+    ]);
+
+    expect(h1({isBig: true, color: "blue"})).toHaveClass([
+      "font-bold",
+      "text-blue-500",
+      "bg-blue-600",
+      "text-7xl",
+    ]);
+
+    expect(h1({isBig: false, color: "red"})).toHaveClass([
+      "font-bold",
+      "text-red-200",
+      "bg-red-600",
+      "tracking-normal",
+      "text-3xl",
+    ]);
+
+    expect(h1({isBig: false, color: "blue"})).toHaveClass([
+      "font-bold",
+      "text-blue-500",
+      "bg-blue-600",
+      "text-3xl",
+    ]);
+  });
+
   test("should include the extended classes with screenVariants single values", () => {
     const p = tv({
       base: "text-base text-green-500",

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,10 +35,10 @@ export const mergeObjects = (obj1, obj2) => {
       const val1 = obj1[key];
       const val2 = obj2[key];
 
-      if (typeof val1 === "object" && typeof val2 === "object") {
-        result[key] = mergeObjects(val1, val2);
-      } else if (Array.isArray(val1) || Array.isArray(val2)) {
+      if (Array.isArray(val1) || Array.isArray(val2)) {
         result[key] = flatMergeArrays(val2, val1);
+      } else if (typeof val1 === "object" && typeof val2 === "object") {
+        result[key] = mergeObjects(val1, val2);
       } else {
         result[key] = val2 + " " + val1;
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When using Arrays on a extended variant it was returning `[object object]`.

By changing the order of the function `mergeObjects` to first check if is an `array` it work as expected (joining the arrays).

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
