### PR TITLE
fix(transformer): add transformer config type to withTV function

### DIFF
--- a/src/transformer.d.ts
+++ b/src/transformer.d.ts
@@ -4,7 +4,7 @@ import type {DefaultTheme} from "tailwindcss/types/generated/default-theme";
 export type DefaultScreens = keyof DefaultTheme["screens"];
 
 export type WithTV = {
-  <C extends Config>(tvConfig: C): C;
+  <C extends Config>(tvConfig: C, config?: TVTransformerConfig): C;
 };
 
 export declare const withTV: WithTV;


### PR DESCRIPTION
### Description

Add `transformerConfig` type to `withTV` function.

### Additional context

Currently we are missing this type in the `transformer.d.ts` file and that causes this issue:

![image](https://github.com/nextui-org/tailwind-variants/assets/23197639/fb28943e-9c9f-4b36-8e47-f4315773ab75)

I was going to open an issue but noticed I could just open a PR directly.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
