### PR TITLE
docs: add `cva` to benchmarks

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 import Benchmark from "benchmark";
+import {cva} from "class-variance-authority";
+import {extendTailwindMerge} from "tailwind-merge";
 
 import {tv} from "./src/index.js";
 
@@ -322,6 +324,57 @@ export const avatarWithCustomConfig = tv(
   },
 );
 
+// CVA without tw-merge config
+const cvaNoMerge = {
+  avatar: cva("relative flex shrink-0 overflow-hidden rounded-full", {
+    variants: {
+      size: {
+        xs: "h-6 w-6",
+        sm: "h-8 w-8",
+        md: "h-10 w-10",
+        lg: "h-12 w-12",
+        xl: "h-14 w-14",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+    compoundVariants: [
+      {
+        size: ["xs", "sm"],
+        class: "ring-1",
+      },
+      {
+        size: ["md", "lg", "xl", "2xl"],
+        class: "ring-2",
+      },
+    ],
+  }),
+  image: cva("aspect-square h-full w-full", {
+    variants: {
+      withBorder: {
+        true: "border-1.5 border-white",
+      },
+    },
+  }),
+  fallback: cva("flex h-full w-full items-center justify-center rounded-full bg-muted", {
+    variants: {
+      size: {
+        xs: "text-xs",
+        sm: "text-sm",
+        md: "text-base",
+        lg: "text-lg",
+        xl: "text-xl",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  }),
+};
+
+const cvaMerge = extendTailwindMerge({extend: twMergeConfig});
+
 // add tests
 suite
   .add("TV without slots & tw-merge (enabled)", function () {
@@ -359,6 +412,16 @@ suite
     base();
     fallback();
     image();
+  })
+  .add("CVA without slots & tw-merge (enabled)", function () {
+    cvaMerge(cvaNoMerge.avatar({size: "md"}));
+    cvaMerge(cvaNoMerge.fallback());
+    cvaMerge(cvaNoMerge.image());
+  })
+  .add("CVA without slots & tw-merge (disabled)", function () {
+    cvaNoMerge.avatar({size: "md"});
+    cvaNoMerge.fallback();
+    cvaNoMerge.image();
   })
 
   // add listeners

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "benchmark": "2.1.4",
+    "class-variance-authority": "^0.7.0",
     "clean-package": "2.1.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ devDependencies:
   benchmark:
     specifier: 2.1.4
     version: 2.1.4
+  class-variance-authority:
+    specifier: ^0.7.0
+    version: 0.7.0
   clean-package:
     specifier: 2.1.1
     version: 2.1.1
@@ -2607,6 +2610,12 @@ packages:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
     dev: true
 
+  /class-variance-authority@0.7.0:
+    resolution: {integrity: sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==}
+    dependencies:
+      clsx: 2.0.0
+    dev: true
+
   /clean-package@2.1.1:
     resolution: {integrity: sha512-+svGAs1RfjguW3Yi0uk1F2gu56jt0nkpFW6Gd9BDK0w7xcIokFwrQOWuRn5NO5pfTDkLCVP1ttIjvJwXaSvRsA==}
     hasBin: true
@@ -2621,6 +2630,11 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+    dev: true
+
+  /clsx@2.0.0:
+    resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
+    engines: {node: '>=6'}
     dev: true
 
   /co@4.6.0:


### PR DESCRIPTION
Fixes #134 

Adds CVA to the benchmarks since a lot of folks often want to compare the perf of the two libraries.

There are only two benchmarks for CVA since it doesn't support slots.

```
TV without slots & tw-merge (enabled) x 743,372 ops/sec ±0.62% (93 runs sampled)
TV without slots & tw-merge (disabled) x 1,006,953 ops/sec ±0.27% (95 runs sampled)
TV with slots & tw-merge (enabled) x 304,484 ops/sec ±1.21% (96 runs sampled)
TV with slots & tw-merge (disabled) x 343,062 ops/sec ±1.04% (98 runs sampled)
TV without slots & custom tw-merge config x 729,188 ops/sec ±1.28% (96 runs sampled)
TV with slots & custom tw-merge config x 404,001 ops/sec ±0.22% (98 runs sampled)
CVA without slots & tw-merge (enabled) x 1,039,518 ops/sec ±0.20% (100 runs sampled)
CVA without slots & tw-merge (disabled) x 1,915,606 ops/sec ±1.87% (97 runs sampled)
Fastest is CVA without slots & tw-merge (disabled)
```