### PR TITLE
(fix): responsive variants for base when slots are present

### DIFF
--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -3,6 +3,7 @@ import type {WithTV, TVTransformer} from "../transformer";
 import {expect, describe, test} from "@jest/globals";
 
 import {tvTransformer, withTV} from "../transformer";
+import {tv, cn} from "../index";
 
 type Mock = {
   withTV: WithTV;
@@ -315,6 +316,78 @@ describe("Responsive Variants", () => {
       },
     ];
 
+    expect(result).toBe(expectedContent(sourceCode, transformedContent));
+  });
+
+  test("should return a transformed content (responsive default base with slot variant)", () => {
+    const sourceCode = `
+      import {tv} from "tailwind-variants";
+
+      const button = tv(
+        {
+          base: "w-fit",
+          slots: {
+            icon: "text-lg"
+          },
+          variants: {
+            size: {
+              sm: "w-[100px]",
+              md: "w-[200px]"
+            }
+          }
+        },
+        {
+          responsiveVariants: true
+        }
+      );
+    `;
+
+    const button = tv(
+      {
+        base: "w-fit",
+        slots: {
+          icon: "text-lg",
+        },
+        variants: {
+          size: {
+            sm: "w-[100px]",
+            md: "w-[200px]",
+          },
+        },
+      },
+      {
+        responsiveVariants: true,
+      },
+    );
+
+    const result = tvTransformer(sourceCode, defaultScreens);
+
+    const {base} = button({size: {initial: "sm", md: "md"}});
+
+    const transformedContent = [
+      {
+        size: {
+          sm: {
+            original: "w-[100px]",
+            sm: "sm:w-[100px]",
+            md: "md:w-[100px]",
+            lg: "lg:w-[100px]",
+            xl: "xl:w-[100px]",
+            "2xl": "2xl:w-[100px]",
+          },
+          md: {
+            original: "w-[200px]",
+            sm: "sm:w-[200px]",
+            md: "md:w-[200px]",
+            lg: "lg:w-[200px]",
+            xl: "xl:w-[200px]",
+            "2xl": "2xl:w-[200px]",
+          },
+        },
+      },
+    ];
+
+    expect(base()).toBe("md:w-[200px] w-[100px]");
     expect(result).toBe(expectedContent(sourceCode, transformedContent));
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -238,7 +238,8 @@ export const tv = (options, configProp) => {
         if (slotKey === "base") {
           return screenValues.join(" ");
         }
-        return screenValues
+
+        return screenValues;
       }
 
       return value;

--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,10 @@ export const tv = (options, configProp) => {
       if (screenValues.length > 0) {
         screenValues.push(value);
 
-        return screenValues;
+        if (slotKey === "base") {
+          return screenValues.join(" ");
+        }
+        return screenValues
       }
 
       return value;


### PR DESCRIPTION
### Description

cc @codecaaron

While trying to use `responsiveVariants` with `slots` present, any responsive props passed were not output in the component's classname.

---

### What is the purpose of this pull request?

Ensure that responsive classnames are applied to `base` correctly when slots are also used.

- [x] Bug fix

Here's a minimal code example of the issue:
```tsx
// example
const button = tv(
    {
        base: 'inline-flex cursor-pointer gap-2 ...',
        slots: {
            icon: 'w-4 h-4 aspect-square pointer-events-auto',
        },
        variants: {
            size: {
                xs: 'text-xs',
                sm: 'text-sm',
                md: 'text-md',
            },
        },
    },
    { responsiveVariants: true },
);

const Button = ({ children, icon: Icon, ...rest }) => {
        const { base, icon } = button(rest)
        return (
            <button {...rest} className={base()} ref={ref}>
                {children}
                {Icon && <Icon className={icon()} />}
            </button>
        );
    };

// responsive variants won't work as expected here. the output classname of this variant will result in undefined
<Button size={{ initial: 'xs', sm: 'sm' }} />
```