### PR TITLE
fix: treat undefined value for compoundVariants as false

### DIFF
--- a/src/__tests__/tv.test.ts
+++ b/src/__tests__/tv.test.ts
@@ -151,17 +151,33 @@ describe("Tailwind Variants (TV) - Default", () => {
           color: "red",
           class: "bg-red-500",
         },
+        {
+          isBig: false,
+          color: "red",
+          class: "underline",
+        },
       ],
     });
 
-    const result = h1({
-      isBig: true,
-      color: "red",
-    });
+    expect(
+      h1({
+        isBig: true,
+        color: "red",
+      }),
+    ).toHaveClass(["text-5xl", "font-bold", "text-red-500", "bg-red-500"]);
 
-    const expectedResult = ["text-5xl", "font-bold", "text-red-500", "bg-red-500"];
+    expect(
+      h1({
+        isBig: false,
+        color: "red",
+      }),
+    ).toHaveClass(["text-2xl", "font-bold", "text-red-500", "underline"]);
 
-    expect(result).toHaveClass(expectedResult);
+    expect(
+      h1({
+        color: "red",
+      }),
+    ).toHaveClass(["text-2xl", "font-bold", "text-red-500", "underline"]);
   });
 
   test("should throw error if the compoundVariants is not an array", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -311,6 +311,10 @@ export const tv = (options, configProp) => {
               break;
             }
           } else {
+            const isBlankOrFalse = (v) => v == null || v === false;
+
+            if (isBlankOrFalse(value) && isBlankOrFalse(completeProps[key])) continue;
+
             if (completeProps[key] !== value) {
               isValid = false;
               break;

--- a/src/index.js
+++ b/src/index.js
@@ -303,19 +303,19 @@ export const tv = (options, configProp) => {
         let isValid = true;
 
         for (const [key, value] of Object.entries(compoundVariantOptions)) {
-          const completeProps = getCompleteProps(key, slotProps);
+          const completePropsValue = getCompleteProps(key, slotProps)[key];
 
           if (Array.isArray(value)) {
-            if (!value.includes(completeProps[key])) {
+            if (!value.includes(completePropsValue)) {
               isValid = false;
               break;
             }
           } else {
             const isBlankOrFalse = (v) => v == null || v === false;
 
-            if (isBlankOrFalse(value) && isBlankOrFalse(completeProps[key])) continue;
+            if (isBlankOrFalse(value) && isBlankOrFalse(completePropsValue)) continue;
 
-            if (completeProps[key] !== value) {
+            if (completePropsValue !== value) {
               isValid = false;
               break;
             }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes a bug where using compoundVariants with a boolean variant doesn't recognize `undefined` as equivalent to `false`.

bug reproduction code:

```js
const h1 = tv({
  base: "",
  variants: {
    isBig: {
      true: "text-5xl",
      false: "text-2xl",
    },
  },
  compoundVariants: [
    {
      isBig: false,
      class: "text-red-500",
    },
  ],
});

h1({ isBig: undefined }) // should get "text-2xl text-red-500", but it's getting "text-2xl"
```

The bug was reported in https://github.com/nextui-org/tailwind-variants/issues/209

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
