### PR TITLE
feat: add cx function and refactor cn to use tailwind-merge

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -3,7 +3,7 @@ import Benchmark from "benchmark";
 import {cva} from "class-variance-authority";
 import {extendTailwindMerge} from "tailwind-merge";
 
-import {tv} from "./src/index.js";
+import {tv, cx, cn} from "./src/index.js";
 
 const suite = new Benchmark.Suite();
 
@@ -375,6 +375,38 @@ const cvaNoMerge = {
 
 const cvaMerge = extendTailwindMerge({extend: twMergeConfig});
 
+// Test data for cx benchmarks
+const simpleClasses = ["text-xl", "font-bold", "text-center", "px-4", "py-2"];
+const arrayClasses = [["px-4", "py-2"], "bg-blue-500", ["rounded-lg", "shadow-md"]];
+const objectClasses = {
+  "text-sm": true,
+  "font-bold": false,
+  "bg-green-200": 1,
+  "m-0": 0,
+  "px-2": true,
+  "py-2": true,
+};
+const mixedClasses = [
+  "text-lg",
+  ["px-3", {"hover:bg-yellow-300": true, "focus:outline-none": false}],
+  {"rounded-md": true, "shadow-md": null},
+  "leading-tight",
+];
+const nestedArrays = [
+  "px-4",
+  ["py-2", ["bg-blue-500", ["rounded-lg", false, ["shadow-md", ["text-white"]]]]],
+];
+const withFalsy = [
+  "text-xl",
+  false && "font-bold",
+  "text-center",
+  undefined,
+  null,
+  0,
+  "",
+  "px-4",
+];
+
 // add tests
 suite
   .add("TV without slots & tw-merge (enabled)", function () {
@@ -422,6 +454,45 @@ suite
     cvaNoMerge.avatar({size: "md"});
     cvaNoMerge.fallback();
     cvaNoMerge.image();
+  })
+  .add("cx - simple strings", function () {
+    cx(...simpleClasses);
+  })
+  .add("cx - arrays", function () {
+    cx(...arrayClasses);
+  })
+  .add("cx - objects", function () {
+    cx(objectClasses);
+  })
+  .add("cx - mixed arguments", function () {
+    cx(...mixedClasses);
+  })
+  .add("cx - nested arrays", function () {
+    cx(...nestedArrays);
+  })
+  .add("cx - with falsy values", function () {
+    cx(...withFalsy);
+  })
+  .add("cn - simple strings (with tw-merge)", function () {
+    cn(...simpleClasses)({twMerge: true});
+  })
+  .add("cn - arrays (with tw-merge)", function () {
+    cn(...arrayClasses)({twMerge: true});
+  })
+  .add("cn - objects (with tw-merge)", function () {
+    cn(objectClasses)({twMerge: true});
+  })
+  .add("cn - mixed arguments (with tw-merge)", function () {
+    cn(...mixedClasses)({twMerge: true});
+  })
+  .add("cn - nested arrays (with tw-merge)", function () {
+    cn(...nestedArrays)({twMerge: true});
+  })
+  .add("cn - with falsy values (with tw-merge)", function () {
+    cn(...withFalsy)({twMerge: true});
+  })
+  .add("cn - simple strings (without tw-merge)", function () {
+    cn(...simpleClasses)({twMerge: false});
   })
 
   // add listeners

--- a/src/__tests__/cn.test.ts
+++ b/src/__tests__/cn.test.ts
@@ -1,61 +1,61 @@
 import {expect, describe, test} from "@jest/globals";
 
-import {cnBase as cnFull} from "../index";
-import {cn as cnLite} from "../lite";
-import {cn as cnUtils} from "../utils";
+import {cn as cnWithMerge, cx as cxFull} from "../index";
+import {cn as cnLite, cx as cxLite} from "../lite";
+import {cx as cxUtils} from "../utils";
 
-const variants = [
-  {name: "full - tailwind-merge", cn: cnFull},
-  {name: "lite - without tailwind-merge", cn: cnLite},
-  {name: "utils - without tailwind-merge", cn: cnUtils},
+const cxVariants = [
+  {name: "main index", cx: cxFull},
+  {name: "lite", cx: cxLite},
+  {name: "utils", cx: cxUtils},
 ];
 
-describe.each(variants)("cn function - $name", ({cn}) => {
+describe("cn function from lite (simple concatenation)", () => {
   test("should join strings and ignore falsy values", () => {
-    expect(cn("text-xl", false && "font-bold", "text-center")).toBe("text-xl text-center");
-    expect(cn("text-xl", undefined, null, 0, "")).toBe("text-xl 0");
+    expect(cnLite("text-xl", false && "font-bold", "text-center")()).toBe("text-xl text-center");
+    expect(cnLite("text-xl", undefined, null, 0, "")()).toBe("text-xl 0");
   });
 
   test("should join arrays of class names", () => {
-    expect(cn(["px-4", "py-2"], "bg-blue-500")).toBe("px-4 py-2 bg-blue-500");
-    expect(cn(["px-4", false, ["hover:bg-red-500", null, "rounded-lg"]])).toBe(
+    expect(cnLite(["px-4", "py-2"], "bg-blue-500")()).toBe("px-4 py-2 bg-blue-500");
+    expect(cnLite(["px-4", false, ["hover:bg-red-500", null, "rounded-lg"]])()).toBe(
       "px-4 hover:bg-red-500 rounded-lg",
     );
   });
 
   test("should handle nested arrays", () => {
-    expect(cn(["px-4", ["py-2", ["bg-blue-500", ["rounded-lg", false, ["shadow-md"]]]]])).toBe(
+    expect(cnLite(["px-4", ["py-2", ["bg-blue-500", ["rounded-lg", false, ["shadow-md"]]]]])()).toBe(
       "px-4 py-2 bg-blue-500 rounded-lg shadow-md",
     );
   });
 
   test("should join objects with truthy values as keys", () => {
-    expect(cn({"text-sm": true, "font-bold": false, "bg-green-200": 1, "m-0": 0})).toBe(
+    expect(cnLite({"text-sm": true, "font-bold": false, "bg-green-200": 1, "m-0": 0})()).toBe(
       "text-sm bg-green-200",
     );
   });
 
   test("should handle mixed arguments correctly", () => {
     expect(
-      cn(
+      cnLite(
         "text-lg",
         ["px-3", {"hover:bg-yellow-300": true, "focus:outline-none": false}],
         {"rounded-md": true, "shadow-md": null},
         "leading-tight",
-      ),
+      )(),
     ).toBe("text-lg px-3 hover:bg-yellow-300 rounded-md leading-tight");
   });
 
   test("should handle numbers and bigint", () => {
-    expect(cn(123, "text-base", 0n, {border: true})).toBe("123 text-base 0 border");
+    expect(cnLite(123, "text-base", 0n, {border: true})()).toBe("123 text-base 0 border");
   });
 
   test("should return undefined for no input", () => {
-    expect(cn()).toBeUndefined();
+    expect(cnLite()()).toBeUndefined();
   });
 
   test("should return '0' for zero and ignore other falsy", () => {
-    expect(cn(false, null, undefined, "", 0)).toBe("0");
+    expect(cnLite(false, null, undefined, "", 0)()).toBe("0");
   });
 
   test("should normalize template strings with irregular whitespace", () => {
@@ -67,10 +67,146 @@ describe.each(variants)("cn function - $name", ({cn}) => {
         rounded-lg
     `;
 
-    expect(cn(input)).toBe("px-4 py-2 bg-blue-500 rounded-lg");
+    expect(cnLite(input)()).toBe("px-4 py-2 bg-blue-500 rounded-lg");
 
     expect(
-      cn(
+      cnLite(
+        ` text-center
+          font-semibold  `,
+        ["text-sm", `   uppercase   `],
+        {"shadow-lg": true, "opacity-50": false},
+      )(),
+    ).toBe("text-center font-semibold text-sm uppercase shadow-lg");
+  });
+
+  test("should handle empty and falsy values correctly", () => {
+    expect(cnLite("", null, undefined, false, NaN, 0, "0")()).toBe("0 0");
+  });
+});
+
+describe("cn function with tailwind-merge (main index)", () => {
+  test("should merge conflicting tailwind classes when twMerge is true", () => {
+    const result = cnWithMerge("px-2", "px-4", "py-2")({twMerge: true});
+
+    expect(result).toBe("px-4 py-2");
+  });
+
+  test("should not merge classes when twMerge is false", () => {
+    const result = cnWithMerge("px-2", "px-4", "py-2")({twMerge: false});
+
+    expect(result).toBe("px-2 px-4 py-2");
+  });
+
+  test("should merge text color classes", () => {
+    const result = cnWithMerge("text-red-500", "text-blue-500")({twMerge: true});
+
+    expect(result).toBe("text-blue-500");
+  });
+
+  test("should merge background color classes", () => {
+    const result = cnWithMerge("bg-red-500", "bg-blue-500")({twMerge: true});
+
+    expect(result).toBe("bg-blue-500");
+  });
+
+  test("should merge multiple conflicting classes", () => {
+    const result = cnWithMerge("px-2 py-1 text-sm", "px-4 py-2 text-lg")({twMerge: true});
+
+    expect(result).toBe("px-4 py-2 text-lg");
+  });
+
+  test("should handle non-conflicting classes", () => {
+    const result = cnWithMerge("px-2", "py-2", "text-sm")({twMerge: true});
+
+    expect(result).toBe("px-2 py-2 text-sm");
+  });
+
+  test("should return undefined when no classes provided", () => {
+    const result = cnWithMerge()({twMerge: true});
+
+    expect(result).toBeUndefined();
+  });
+
+  test("should handle arrays with tailwind-merge", () => {
+    const result = cnWithMerge(["px-2", "px-4"], "py-2")({twMerge: true});
+
+    expect(result).toBe("px-4 py-2");
+  });
+
+  test("should handle objects with tailwind-merge", () => {
+    const result = cnWithMerge({"px-2": true, "px-4": true, "py-2": true})({twMerge: true});
+
+    expect(result).toBe("px-4 py-2");
+  });
+
+  test("should merge when config is undefined (default behavior)", () => {
+    const result = cnWithMerge("px-2", "px-4")({twMerge: true});
+
+    expect(result).toBe("px-4");
+  });
+});
+
+describe.each(cxVariants)("cx function - $name", ({cx}) => {
+  test("should join strings and ignore falsy values", () => {
+    expect(cx("text-xl", false && "font-bold", "text-center")).toBe("text-xl text-center");
+    expect(cx("text-xl", undefined, null, 0, "")).toBe("text-xl 0");
+  });
+
+  test("should join arrays of class names", () => {
+    expect(cx(["px-4", "py-2"], "bg-blue-500")).toBe("px-4 py-2 bg-blue-500");
+    expect(cx(["px-4", false, ["hover:bg-red-500", null, "rounded-lg"]])).toBe(
+      "px-4 hover:bg-red-500 rounded-lg",
+    );
+  });
+
+  test("should handle nested arrays", () => {
+    expect(cx(["px-4", ["py-2", ["bg-blue-500", ["rounded-lg", false, ["shadow-md"]]]]])).toBe(
+      "px-4 py-2 bg-blue-500 rounded-lg shadow-md",
+    );
+  });
+
+  test("should join objects with truthy values as keys", () => {
+    expect(cx({"text-sm": true, "font-bold": false, "bg-green-200": 1, "m-0": 0})).toBe(
+      "text-sm bg-green-200",
+    );
+  });
+
+  test("should handle mixed arguments correctly", () => {
+    expect(
+      cx(
+        "text-lg",
+        ["px-3", {"hover:bg-yellow-300": true, "focus:outline-none": false}],
+        {"rounded-md": true, "shadow-md": null},
+        "leading-tight",
+      ),
+    ).toBe("text-lg px-3 hover:bg-yellow-300 rounded-md leading-tight");
+  });
+
+  test("should handle numbers and bigint", () => {
+    expect(cx(123, "text-base", 0n, {border: true})).toBe("123 text-base 0 border");
+  });
+
+  test("should return undefined for no input", () => {
+    expect(cx()).toBeUndefined();
+  });
+
+  test("should return '0' for zero and ignore other falsy", () => {
+    expect(cx(false, null, undefined, "", 0)).toBe("0");
+  });
+
+  test("should normalize template strings with irregular whitespace", () => {
+    const input = `
+      px-4
+      py-2
+
+      bg-blue-500
+        rounded-lg
+    `;
+
+    expect(cx(input)).toBe("px-4 py-2 bg-blue-500 rounded-lg");
+
+    expect(
+      cx(
         ` text-center
           font-semibold  `,
         ["text-sm", `   uppercase   `],
@@ -80,6 +216,15 @@ describe.each(variants)("cn function - $name", ({cn}) => {
   });
 
   test("should handle empty and falsy values correctly", () => {
-    expect(cn("", null, undefined, false, NaN, 0, "0")).toBe("0 0");
+    expect(cx("", null, undefined, false, NaN, 0, "0")).toBe("0 0");
+  });
+
+  test("should NOT merge conflicting classes (simple concatenation)", () => {
+    // cx should just concatenate, not merge
+    expect(cx("px-2", "px-4", "py-2")).toBe("px-2 px-4 py-2");
+  });
+
+  test("should handle conflicting classes without merging", () => {
+    expect(cx("text-red-500", "text-blue-500")).toBe("text-red-500 text-blue-500");
   });
 });

--- a/src/core.js
+++ b/src/core.js
@@ -6,7 +6,7 @@ import {
   removeExtraSpaces,
   flatMergeArrays,
   joinObjects,
-  cn as cnBase,
+  cx,
 } from "./utils.js";
 import {defaultConfig} from "./config.js";
 import {state} from "./state.js";
@@ -24,7 +24,7 @@ export const getTailwindVariants = (cn) => {
 
     const config = {...defaultConfig, ...configProp};
 
-    const base = extend?.base ? cnBase(extend.base, options?.base) : options?.base;
+    const base = extend?.base ? cx(extend.base, options?.base) : options?.base;
     const variants =
       extend?.variants && !isEmptyObject(extend.variants)
         ? mergeObjects(variantsProps, extend.variants)
@@ -47,7 +47,7 @@ export const getTailwindVariants = (cn) => {
     const componentSlots = !isEmptyObject(slotProps)
       ? {
           // add "base" to the slots object
-          base: cnBase(options?.base, isExtendedSlotsEmpty && extend?.base),
+          base: cx(options?.base, isExtendedSlotsEmpty && extend?.base),
           ...slotProps,
         }
       : {};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,7 +4,7 @@ import type {CnOptions, CnReturn, TV} from "./types.d.ts";
 export type * from "./types.d.ts";
 
 // util function
-export declare const cnBase: <T extends CnOptions>(...classes: T) => CnReturn;
+export declare const cx: <T extends CnOptions>(...classes: T) => CnReturn;
 
 export declare const cn: <T extends CnOptions>(...classes: T) => (config?: TWMConfig) => CnReturn;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import {getTailwindVariants} from "./core.js";
 import {cn} from "./tw-merge.js";
-import {cn as cnBase} from "./utils.js";
+import {cx} from "./utils.js";
 import {defaultConfig} from "./config.js";
 
 export const {createTV, tv} = getTailwindVariants(cn);
 
-export {cn, cnBase, defaultConfig};
+export {cn, cx, defaultConfig};

--- a/src/lite.d.ts
+++ b/src/lite.d.ts
@@ -3,7 +3,7 @@ import type {CnOptions, CnReturn, TVLite} from "./types.d.ts";
 export type * from "./types.d.ts";
 
 // util function
-export declare const cnBase: <T extends CnOptions>(...classes: T) => CnReturn;
+export declare const cx: <T extends CnOptions>(...classes: T) => CnReturn;
 
 export declare const cn: <T extends CnOptions>(...classes: T) => CnReturn;
 

--- a/src/lite.js
+++ b/src/lite.js
@@ -1,10 +1,10 @@
-import {cn as cnBase} from "./utils.js";
+import {cx} from "./utils.js";
 import {getTailwindVariants} from "./core.js";
 import {defaultConfig} from "./config.js";
 
 export const cnAdapter = (...classnames) => {
   return (_config) => {
-    const base = cnBase(classnames);
+    const base = cx(classnames);
 
     return base || undefined;
   };
@@ -12,4 +12,4 @@ export const cnAdapter = (...classnames) => {
 
 export const {createTV, tv} = getTailwindVariants(cnAdapter);
 
-export {cnBase as cn, cnBase, defaultConfig};
+export {cnAdapter as cn, cx, defaultConfig};

--- a/src/tw-merge.js
+++ b/src/tw-merge.js
@@ -1,6 +1,6 @@
 import {twMerge as twMergeBase, extendTailwindMerge} from "tailwind-merge";
 
-import {isEmptyObject, cn as cnBase} from "./utils.js";
+import {isEmptyObject, cx} from "./utils.js";
 import {state} from "./state.js";
 
 export const createTwMerge = (cachedTwMergeConfig) => {
@@ -20,7 +20,7 @@ export const createTwMerge = (cachedTwMergeConfig) => {
 
 export const cn = (...classnames) => {
   return (config) => {
-    const base = cnBase(classnames);
+    const base = cx(classnames);
 
     if (!base || !config.twMerge) return base;
 

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -1,4 +1,3 @@
-import type {TWMConfig} from "./config.d.ts";
 import type {CnOptions, CnReturn} from "./types.d.ts";
 
 export declare const falsyToString: <T>(value: T) => T | string;
@@ -30,4 +29,4 @@ export declare const joinObjects: <
 
 export declare const flat: <T>(arr: unknown[], target: T[]) => void;
 
-export declare const cn: <T extends CnOptions>(...classes: T) => (config?: TWMConfig) => CnReturn;
+export declare const cx: <T extends CnOptions>(...classes: T) => CnReturn;

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,8 @@ export const removeExtraSpaces = (str) => {
   return str.replace(SPACE_REGEX, " ").trim();
 };
 
-export const cn = (...classnames) => {
+// cx - simple class name concatenation (like clsx)
+export const cx = (...classnames) => {
   const classList = [];
 
   // recursively process input
@@ -87,7 +88,7 @@ export const joinObjects = (obj1, obj2) => {
       const val2 = obj2[key];
 
       if (key in obj1) {
-        obj1[key] = cn(obj1[key], val2);
+        obj1[key] = cx(obj1[key], val2);
       } else {
         obj1[key] = val2;
       }


### PR DESCRIPTION
# Add `cx` function and refactor `cn` to use tailwind-merge

## Overview

This PR introduces a new `cx` function for simple class name concatenation (similar to `clsx`) and refactors `cn` to exclusively support **tailwind-merge** functionality. This provides a clearer separation of concerns and better developer experience.

## What's New

### ✨ New `cx` Function

A new `cx` function is now available for simple class name concatenation without tailwind-merge:

```typescript
import {cx} from "tailwind-variants";

// Simple concatenation (like clsx)
cx("text-xl", "font-bold", "text-center");
// => "text-xl font-bold text-center"

// Supports arrays, objects, and nested structures
cx(["px-4", "py-2"], {"text-sm": true, "font-bold": false});
// => "px-4 py-2 text-sm"
```

**Available in:**
- Main entry: `import {cx} from "tailwind-variants"`
- Lite entry: `import {cx} from "tailwind-variants/lite"`
- Utils entry: `import {cx} from "tailwind-variants/utils"`

### 🔄 Refactored `cn` Function

The `cn` function now exclusively supports tailwind-merge functionality:

```typescript
import {cn} from "tailwind-variants";

// With tailwind-merge (conflict resolution)
cn("px-2", "px-4", "py-2")({twMerge: true});
// => "px-4 py-2" (px-2 is merged/overridden by px-4)

// Without tailwind-merge
cn("px-2", "px-4", "py-2")({twMerge: false});
// => "px-2 px-4 py-2"
```

**Available in:**
- Main entry: `import {cn} from "tailwind-variants"` (with tailwind-merge support)
- Lite entry: `import {cn} from "tailwind-variants/lite"` (simple concatenation adapter)

## Breaking Changes

### 🚨 Removed `cnBase` Export

The `cnBase` export has been **removed** from all entry points. Use `cx` instead.

**Before:**
```typescript
import {cnBase} from "tailwind-variants";

const classes = cnBase("text-xl", "font-bold");
```

**After:**
```typescript
import {cx} from "tailwind-variants";

const classes = cx("text-xl", "font-bold");
```

### 🔄 `cn` Function Signature Change

The `cn` function from the main entry point now requires a curried call pattern (it returns a function that accepts a config).

**Before:**
```typescript
import {cnBase as cn} from "tailwind-variants";

const classes = cn("text-xl", "font-bold");
// Direct call, no config
```

**After:**
```typescript
import {cn} from "tailwind-variants";

// With tailwind-merge
const classes = cn("text-xl", "font-bold")({twMerge: true});

// Without tailwind-merge
const classes = cn("text-xl", "font-bold")({twMerge: false});
```

**Note:** If you need simple concatenation without tailwind-merge, use `cx` instead:

```typescript
import {cx} from "tailwind-variants";

const classes = cx("text-xl", "font-bold");
// Direct call, no config needed
```

### 📦 Utils Entry Point Changes

The `cn` export has been removed from the utils entry point. Only `cx` is available.

**Before:**
```typescript
import {cn} from "tailwind-variants/utils";
```

**After:**
```typescript
import {cx} from "tailwind-variants/utils";
```

## Migration Guide

### Step 1: Replace `cnBase` with `cx`

Search and replace all instances of `cnBase` with `cx`:

```diff
- import {cnBase} from "tailwind-variants";
+ import {cx} from "tailwind-variants";

- const classes = cnBase("text-xl", "font-bold");
+ const classes = cx("text-xl", "font-bold");
```

### Step 2: Update `cn` Usage

If you were using `cn` for simple concatenation (without tailwind-merge), switch to `cx`:

```diff
- import {cn} from "tailwind-variants";
+ import {cx} from "tailwind-variants";

- const classes = cn("text-xl", "font-bold");
+ const classes = cx("text-xl", "font-bold");
```

If you need tailwind-merge functionality, use `cn` with the config:

```typescript
import {cn} from "tailwind-variants";

// Enable tailwind-merge
const classes = cn("px-2", "px-4")({twMerge: true});
// => "px-4"

// Disable tailwind-merge
const classes = cn("px-2", "px-4")({twMerge: false});
// => "px-2 px-4"
```

### Step 3: Update Utils Imports

If you were importing `cn` from utils:

```diff
- import {cn} from "tailwind-variants/utils";
+ import {cx} from "tailwind-variants/utils";
```

## Function Comparison

| Function | Entry Point | Tailwind-Merge | Signature | Use Case |
|----------|-------------|----------------|-----------|----------|
| `cx` | All entries | ❌ No | `cx(...classes)` | Simple concatenation (like clsx) |
| `cn` | Main entry | ✅ Yes | `cn(...classes)(config)` | With tailwind-merge conflict resolution |
| `cn` | Lite entry | ❌ No | `cn(...classes)()` | Simple concatenation adapter |

## Benefits

1. **Clearer API**: `cx` for concatenation, `cn` for tailwind-merge
2. **Better Performance**: `cx` is faster for simple concatenation (no merge overhead)
3. **Type Safety**: Improved TypeScript types for both functions
4. **Consistency**: Aligns with common patterns (`clsx`-like API)

## Testing

All existing tests pass, and new comprehensive tests have been added for:
- `cx` function across all entry points
- `cn` function with tailwind-merge
- Edge cases (falsy values, nested arrays, objects)

## Benchmarks

New benchmarks have been added to `benchmark.js` comparing:
- `cx` performance across different input types
- `cn` performance with and without tailwind-merge
- Performance overhead of tailwind-merge

```
TV without slots & tw-merge (enabled) x 537,374 ops/sec ±0.44% (94 runs sampled)
TV without slots & tw-merge (disabled) x 693,519 ops/sec ±0.38% (96 runs sampled)
TV with slots & tw-merge (enabled) x 295,138 ops/sec ±0.75% (96 runs sampled)
TV with slots & tw-merge (disabled) x 349,142 ops/sec ±0.73% (90 runs sampled)
TV without slots & custom tw-merge config x 531,989 ops/sec ±0.43% (95 runs sampled)
TV with slots & custom tw-merge config x 359,053 ops/sec ±0.38% (99 runs sampled)
CVA without slots & tw-merge (enabled) x 1,383,625 ops/sec ±0.26% (99 runs sampled)
CVA without slots & tw-merge (disabled) x 2,990,558 ops/sec ±0.35% (97 runs sampled)
cx - simple strings x 3,369,331 ops/sec ±0.23% (99 runs sampled)
cx - arrays x 3,137,940 ops/sec ±0.25% (100 runs sampled)
cx - objects x 3,756,281 ops/sec ±0.22% (94 runs sampled)
cx - mixed arguments x 2,817,673 ops/sec ±0.31% (96 runs sampled)
cx - nested arrays x 2,559,536 ops/sec ±0.19% (98 runs sampled)
cx - with falsy values x 3,650,998 ops/sec ±0.37% (99 runs sampled)
cn - simple strings (with tw-merge) x 2,415,101 ops/sec ±0.19% (95 runs sampled)
cn - arrays (with tw-merge) x 2,314,489 ops/sec ±0.22% (98 runs sampled)
cn - objects (with tw-merge) x 2,772,192 ops/sec ±0.28% (100 runs sampled)
cn - mixed arguments (with tw-merge) x 2,030,302 ops/sec ±0.14% (98 runs sampled)
cn - nested arrays (with tw-merge) x 1,921,356 ops/sec ±0.15% (99 runs sampled)
cn - with falsy values (with tw-merge) x 2,623,581 ops/sec ±0.23% (97 runs sampled)
cn - simple strings (without tw-merge) x 3,090,209 ops/sec ±0.25% (99 runs sampled)
Fastest is cx - objects
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests added/updated and passing
- [x] TypeScript types updated
- [x] Documentation updated
- [x] Breaking changes documented
- [x] Migration guide provided
- [x] Benchmarks added


