### PR TITLE
fix: update cn function type and import cx from tailwind-variants/lite

### DIFF
--- a/MIGRATION-V3.md
+++ b/MIGRATION-V3.md
@@ -33,5 +33,5 @@ pnpm add tailwind-merge
 If you do not need conflict resolution, switch to the lite build by importing from `tailwind-variants/lite`:
 
 ```ts
-import {createTV, tv, cn, cnBase} from "tailwind-variants/lite";
+import {createTV, tv, cn, cx} from "tailwind-variants/lite";
 ```

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,6 +22,16 @@ export type * from "./types.d.ts";
 export declare const cx: <T extends CnOptions>(...classes: T) => CnReturn;
 
 /**
+ * Type representing a callable function that can also be coerced to a string.
+ * This allows `cn` to work both as a function and directly in template literals.
+ */
+type CnCallable = ((config?: TWMConfig) => CnReturn) & {
+  toString(): string;
+  valueOf(): CnReturn;
+  [Symbol.toPrimitive](hint: "string" | "number" | "default"): string | CnReturn;
+} & string;
+
+/**
  * Combines class names and merges conflicting Tailwind CSS classes using `tailwind-merge`.
  * @param classes - Class names to combine (strings, arrays, objects, etc.)
  * @returns A callable function that returns the merged class string. Works directly in template literals (coerces to string) or can be called with optional config.
@@ -39,7 +49,7 @@ export declare const cx: <T extends CnOptions>(...classes: T) => CnReturn;
  * // Use: cx('bg-red-500', 'bg-blue-500') // => 'bg-red-500 bg-blue-500'
  * ```
  */
-export declare const cn: <T extends CnOptions>(...classes: T) => (config?: TWMConfig) => CnReturn;
+export declare const cn: <T extends CnOptions>(...classes: T) => CnCallable;
 
 /**
  * Creates a variant-aware component function with Tailwind CSS classes.


### PR DESCRIPTION
- Change the type of cn function to allow callable string representation.
- Update import statement in MIGRATION-V3.md to use cx instead of cnBase.

<!-- Thank you for contributing! -->

### Description

Fix this issue:

```ts
Type '(config?: TWMConfig | undefined) => CnReturn' is not assignable to type 'string'.
```


```
  // before
  <div className={cn("flex items-center justify-center gap-2", className)()}>

// after
  <div className={cn("flex items-center justify-center gap-2", className)}>
```



### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
